### PR TITLE
Package UIZZE for Claude Code, Codex, and Cursor

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "uizze",
+  "interface": {
+    "displayName": "UIZZE"
+  },
+  "plugins": [
+    {
+      "name": "uizze",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/samuelbushi/uizze.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,34 @@
+{
+  "name": "uizze",
+  "owner": {
+    "name": "UIZZE",
+    "email": "business@uizze.com"
+  },
+  "metadata": {
+    "description": "The official UIZZE plugin marketplace for shipping product-specific interfaces instead of generic UI slop.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "uizze",
+      "source": "./",
+      "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+      "version": "1.0.0",
+      "author": {
+        "name": "UIZZE",
+        "email": "business@uizze.com"
+      },
+      "homepage": "https://uizze.com",
+      "repository": "https://github.com/samuelbushi/uizze",
+      "license": "MIT",
+      "keywords": [
+        "ui",
+        "design",
+        "frontend",
+        "anti-slop",
+        "agent-skill"
+      ],
+      "category": "Development"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "uizze",
+  "displayName": "UIZZE",
+  "version": "1.0.0",
+  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com",
+    "url": "https://uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/samuelbushi/uizze",
+  "license": "MIT",
+  "keywords": [
+    "ui",
+    "design",
+    "frontend",
+    "anti-slop",
+    "agent-skill"
+  ],
+  "skills": "./skills/"
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "uizze",
+  "version": "1.0.0",
+  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com",
+    "url": "https://uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/samuelbushi/uizze",
+  "license": "MIT",
+  "keywords": [
+    "ui",
+    "design",
+    "frontend",
+    "anti-slop",
+    "agent-skill"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "UIZZE",
+    "shortDescription": "Stop generic UI slop",
+    "longDescription": "Ground interface work in real product evidence, define a product-specific design contract, and run a hard finish gate before shipping.",
+    "developerName": "UIZZE",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://uizze.com",
+    "privacyPolicyURL": "https://uizze.com/privacy",
+    "termsOfServiceURL": "https://uizze.com/terms",
+    "defaultPrompt": [
+      "Use UIZZE to plan this interface from real product evidence.",
+      "Run the UIZZE finish gate on this frontend.",
+      "Use UIZZE to remove generic patterns from this UI."
+    ],
+    "brandColor": "#111111"
+  }
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "uizze",
+  "displayName": "UIZZE",
+  "version": "1.0.0",
+  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/samuelbushi/uizze",
+  "license": "MIT",
+  "keywords": [
+    "ui",
+    "design",
+    "frontend",
+    "anti-slop",
+    "agent-skill"
+  ],
+  "logo": "https://uizze.com/brand/icons/uizze-web-app-icon-512x512.png",
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,28 @@ UIZZE gives Codex, Claude Code, Cursor, and other coding agents a repeatable way
 
 The `anti-ui-slop` skill and public catalogue workflow are free. The full UIZZE MCP adds automated catalogue search, design contracts, validation, audits, and screenshot critique.
 
-## Install
+## Install the free workflow
+
+### Codex, Claude Code, Cursor, and Copilot
 
 ```bash
 npx skills add samuelbushi/uizze --skill anti-ui-slop
 ```
+
+### Claude Code plugin
+
+```text
+/plugin marketplace add samuelbushi/uizze
+/plugin install uizze@uizze
+```
+
+### Codex plugin marketplace
+
+```bash
+codex plugin marketplace add samuelbushi/uizze
+```
+
+Then open the UIZZE marketplace in Plugins and install UIZZE.
 
 Then ask your agent:
 
@@ -31,6 +48,10 @@ It does not copy another product's branding, proprietary text, imagery, or exact
 ## Repository structure
 
 ```text
+├── .agents/plugins/marketplace.json
+├── .claude-plugin/
+├── .codex-plugin/
+├── .cursor-plugin/
 skills/
 └── anti-ui-slop/
     ├── SKILL.md


### PR DESCRIPTION
## What
- packages the existing free anti-ui-slop skill as a native Claude Code plugin
- adds Codex plugin and marketplace manifests
- adds a Cursor plugin manifest for marketplace submission
- documents direct install paths without changing the existing skills.sh identity

## Positioning
UIZZE stops generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens. The paid MCP remains an optional upgrade inside the skill.

## Validation
- `claude plugin validate .`
- Codex plugin validator
- JSON parse checks
- `git diff --check`