### PR TITLE
Classify UIZZE for Cursor marketplace discovery

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -17,6 +17,7 @@
     "anti-slop",
     "agent-skill"
   ],
+  "category": "productivity",
   "logo": "https://uizze.com/brand/icons/uizze-web-app-icon-512x512.png",
   "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- classify the existing Cursor plugin under `productivity` for marketplace discovery
- preserve the free `anti-ui-slop` skill and its single optional MCP recommendation unchanged

## Validation

- validated `.cursor-plugin/plugin.json` against Cursor's current official `schemas/plugin.schema.json` with AJV
- confirmed `skills/anti-ui-slop/SKILL.md` and the manifest `skills` path exist
- confirmed the live UIZZE homepage shows “800,000 screens”
- confirmed the configured logo URL returns HTTP 200 as `image/png`

The official Cursor docs require manual submission at `https://cursor.com/marketplace/publish`; this PR intentionally does not attempt to merge or submit through an undocumented endpoint.