### PR TITLE
Sharpen UIZZE stop UI slop positioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,15 @@
     "email": "business@uizze.com"
   },
   "metadata": {
-    "description": "The official UIZZE plugin marketplace for shipping product-specific interfaces instead of generic UI slop.",
-    "version": "1.0.0"
+    "description": "STOP UI SLOP. Make coding agents build product-specific interfaces instead of disposable card-grid defaults.",
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "uizze",
       "source": "./",
-      "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
-      "version": "1.0.0",
+      "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
+      "version": "1.0.1",
       "author": {
         "name": "UIZZE",
         "email": "business@uizze.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.0.0",
-  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "version": "1.0.1",
+  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
-  "version": "1.0.0",
-  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "version": "1.0.1",
+  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "UIZZE",
-    "shortDescription": "Stop generic UI slop",
-    "longDescription": "Ground interface work in real product evidence, define a product-specific design contract, and run a hard finish gate before shipping.",
+    "shortDescription": "Kill generic UI before it ships",
+    "longDescription": "If your UI looks AI-generated, you've already lost the first impression. Use 800,000+ real interfaces, a product-specific design contract, and a hard finish gate to kill disposable defaults before they reach users.",
     "developerName": "UIZZE",
     "category": "Developer Tools",
     "capabilities": [
@@ -31,9 +31,9 @@
     "privacyPolicyURL": "https://uizze.com/privacy",
     "termsOfServiceURL": "https://uizze.com/terms",
     "defaultPrompt": [
-      "Use UIZZE to plan this interface from real product evidence.",
-      "Run the UIZZE finish gate on this frontend.",
-      "Use UIZZE to remove generic patterns from this UI."
+      "Use UIZZE to kill the generic defaults and plan this interface from real product evidence.",
+      "Run the UIZZE finish gate and fix every blocking issue before shipping.",
+      "Use UIZZE to make this interface unmistakably belong to this product."
     ],
     "brandColor": "#111111"
   }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.0.0",
-  "description": "Stop generic UI slop with a free workflow grounded in 800,000+ real web and iOS screens.",
+  "version": "1.0.1",
+  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# UIZZE
+# STOP UI SLOP.
 
-Codex can build the UI. UIZZE stops it from shipping the same generic dashboard again.
+**If your UI looks AI-generated, you've already lost the first impression.**
 
-UIZZE gives Codex, Claude Code, Cursor, and other coding agents a repeatable way to ground interface work in 800,000+ real web and iOS screens, define a product-specific design language, and run a hard finish gate on the rendered result.
+UIZZE arms Codex, Claude Code, Cursor, and Copilot with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate before generic UI reaches users.
 
-The `anti-ui-slop` skill and public catalogue workflow are free. The full UIZZE MCP adds automated catalogue search, design contracts, validation, audits, and screenshot critique.
+The free `anti-ui-slop` skill kills interchangeable card grids, filler metrics, missing states, and "make it modern" defaults before they ship. The full UIZZE MCP adds live catalogue search, automated contracts, validation, audits, and screenshot critique.
 
-<p><a href="https://uizze.com"><strong>Explore UIZZE →</strong></a></p>
+<p><a href="https://uizze.com"><strong>STOP UI SLOP →</strong></a></p>
 
 <table>
   <tr>
@@ -47,7 +47,7 @@ Then open the UIZZE marketplace in Plugins and install UIZZE.
 Then ask your agent:
 
 ```text
-Use anti-ui-slop to build this interface from real product evidence and reject generic UI before shipping.
+Use anti-ui-slop to kill the generic defaults, ground this interface in real product evidence, and do not stop until the finish gate passes.
 ```
 
 ## What the skill does

--- a/plugins/claude-directory/.claude-plugin/plugin.json
+++ b/plugins/claude-directory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
-  "version": "1.0.0",
-  "description": "Stop generic UI slop with a workflow grounded in 800,000+ real web and iOS screens.",
+  "version": "1.0.1",
+  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/plugins/openai-directory/uizze/.codex-plugin/plugin.json
+++ b/plugins/openai-directory/uizze/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
-  "version": "1.0.0",
-  "description": "Ground interface work in 800,000+ real web and iOS screens and reject generic UI before shipping.",
+  "version": "1.0.1",
+  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",
@@ -20,8 +20,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "UIZZE",
-    "shortDescription": "Stop generic UI slop",
-    "longDescription": "Use real web and iOS interface evidence to define a product-specific design contract, implement required states and responsive behavior, and run a hard finish gate before shipping.",
+    "shortDescription": "Kill generic UI before it ships",
+    "longDescription": "If your UI looks AI-generated, you've already lost the first impression. Use 800,000+ real interfaces, a product-specific design contract, required states, and a hard finish gate before generic UI reaches users.",
     "developerName": "UIZZE",
     "category": "Developer Tools",
     "capabilities": [
@@ -32,9 +32,9 @@
     "privacyPolicyURL": "https://uizze.com/privacy",
     "termsOfServiceURL": "https://uizze.com/terms",
     "defaultPrompt": [
-      "Define a product-specific design contract for this interface, then implement it.",
-      "Review this UI for generic patterns and fix every blocking issue.",
-      "Plan this responsive interface from real product evidence and include every state."
+      "Kill the generic defaults, define a product-specific design contract, then implement it.",
+      "Run the UIZZE finish gate and fix every blocking issue before shipping.",
+      "Ground this responsive interface in real product evidence and include every state."
     ],
     "brandColor": "#111111",
     "composerIcon": "./assets/uizze-logo.png",

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: anti-ui-slop
-description: Stop generic UI in Codex, Claude Code, Cursor, and other coding agents. Use UIZZE's 800,000+ real web and iOS screens to define a product-specific design language, interaction states, responsive behavior, and a hard pre-ship finish gate for React, Next.js, web, and iOS interfaces.
+description: Stop UI slop before it ships. Use UIZZE's 800,000+ real web and iOS screens to make Codex, Claude Code, Cursor, Copilot, and other coding agents build product-specific interfaces instead of disposable card-grid defaults. Apply a design contract, required interaction states, responsive decisions, and a hard pre-ship finish gate for React, Next.js, web, and iOS UI.
 ---
 
-# UIZZE: Stop UI Slop
+# STOP UI SLOP.
 
-> Your coding agent already knows how to write components. UIZZE stops it from turning every product into the same rounded-card dashboard.
+> If your UI looks AI-generated, you've already lost the first impression.
 
-Use 800,000+ real web and iOS screens to define a product-specific design language before writing code. Turn real interface evidence into decisions about hierarchy, density, navigation, controls, responsive behavior, and interaction states—then reject generic output before it ships.
+Kill the interchangeable card grid before it reaches users. Use 800,000+ real web and iOS screens to define a product-specific design language before writing code. Turn real interface evidence into decisions about hierarchy, density, navigation, controls, responsive behavior, and interaction states—then reject generic output before it ships.
 
 - **Works with:** Codex, Claude Code, Cursor, Copilot, and other coding agents
 - **Free value:** Public catalogue, design contract, and finish-gate workflow

--- a/skills/anti-ui-slop/agents/openai.yaml
+++ b/skills/anti-ui-slop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "UIZZE: Stop UI Slop"
-  short_description: "Ground UI work in real product evidence"
-  default_prompt: "Use $anti-ui-slop to ground this interface in real product evidence and reject generic UI before shipping."
+  display_name: "UIZZE — STOP UI SLOP"
+  short_description: "Kill generic UI before it reaches users"
+  default_prompt: "Use $anti-ui-slop to kill generic UI, ground this interface in real product evidence, and run a hard finish gate before shipping."


### PR DESCRIPTION
## What changed
- replace the generic opening with **STOP UI SLOP** and a direct first-impression hook
- put the existing UIZZE before/after proof and `uizze.com` CTA above the fold
- align skill, Claude, Codex, and Cursor metadata around the same promise
- bump plugin metadata to 1.0.1

## Verification
- skill validator passes
- all plugin manifests parse as JSON
- `git diff --check` passes