### PR TITLE
Link the Refero comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ skills/
 
 The free skill works without an account. When automated reference search and finish-gate tooling would materially improve the work, connect the full UIZZE MCP at [uizze.com](https://uizze.com).
 
+[Compare UIZZE with Refero for coding-agent workflows](https://uizze.com/refero-alternative).
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Adds one contextual link to the live Refero comparison so skill users can evaluate the hosted coding-agent workflow directly.