### PR TITLE
Add Codex marketplace security scan

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",
@@ -22,6 +22,7 @@
     "displayName": "UIZZE",
     "shortDescription": "Kill generic UI before it ships",
     "longDescription": "If your UI looks AI-generated, you've already lost the first impression. Use 800,000+ real interfaces, a product-specific design contract, and a hard finish gate to kill disposable defaults before they reach users.",
+    "composerIcon": "./plugins/openai-directory/uizze/assets/uizze-logo.png",
     "developerName": "UIZZE",
     "category": "Developer Tools",
     "capabilities": [

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,29 @@
+name: HOL Plugin Scanner
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Scan UIZZE plugin
+        uses: hashgraph-online/ai-plugin-scanner-action@8f0a503ca2a70c1968a9a883e11fdff5737b7909
+        with:
+          plugin_dir: "."
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true


### PR DESCRIPTION
## What changed

- add the mandatory HOL plugin scanner workflow with commit-pinned actions
- expose the existing 512px UIZZE icon through the Codex plugin manifest
- bump the plugin bundle version to `1.0.2`

## Why

This makes the public UIZZE plugin eligible for review by the Awesome Codex Plugins marketplace without changing the free anti-UI-slop workflow or its claims.

## Validation

- `python3 -m json.tool .codex-plugin/plugin.json`
- `git diff --check`
- verified the scanner wheel SHA-256 for `plugin-scanner==2.0.1015`: `c1302897304e9b7fd74cb92d6057a1785e6430fb64bd70e8f90b14267deb0e0b`
- GitHub Actions will run the authoritative scanner on this pull request
