### PR TITLE
Link the Gummble comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The free skill works without an account. When automated reference search and fin
 
 [Compare UIZZE with Refero for coding-agent workflows](https://uizze.com/refero-alternative).
 
+[Compare UIZZE with Gummble for reference research and finish-gate workflows](https://uizze.com/gummble-alternative).
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Add the live UIZZE-vs-Gummble comparison beside the existing Refero comparison so public skill/plugin visitors can evaluate reference research and finish-gate workflows directly.

Validation: target returns HTTP 200; README-only diff; `git diff --check` passes.