### PR TITLE
Prepare UIZZE OpenAI directory package

### DIFF
--- a/plugins/openai-directory/uizze/.codex-plugin/plugin.json
+++ b/plugins/openai-directory/uizze/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
   "author": {
     "name": "UIZZE",

--- a/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
+++ b/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anti-ui-slop
-description: Stop generic AI-generated UI by grounding React, Next.js, web, and iOS work in real product evidence, defining a product-specific design contract, implementing interaction and responsive states, and enforcing a hard pre-ship finish gate.
+description: Stop generic UI by grounding React, Next.js, web, and iOS work in real product evidence, defining a product-specific design contract, implementing interaction and responsive states, and enforcing a hard pre-ship finish gate.
 ---
 
 # UIZZE: Stop UI Slop


### PR DESCRIPTION
## What changed
- sync the self-contained OpenAI skills-only package to v1.0.2
- keep the trigger language focused on UI slop rather than redundant AI wording

## Verification
- skill-creator quick validation passes
- manifest JSON and referenced logo validate locally

This prepares the exact package for the official ChatGPT/Codex Plugins Directory upload.