### PR TITLE
Prepare UIZZE for Cursor Marketplace

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.0.1",
-  "description": "STOP UI SLOP. Ground coding agents in 800,000+ real web and iOS screens before generic UI ships.",
+  "version": "1.1.0",
+  "description": "STOP UI SLOP. Ground Cursor in 800,000+ real web and iOS screens, then block generic UI at the finish gate.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com"
@@ -14,10 +14,12 @@
     "ui",
     "design",
     "frontend",
+    "cursor",
+    "mcp",
     "anti-slop",
     "agent-skill"
   ],
   "category": "productivity",
-  "logo": "https://uizze.com/brand/icons/uizze-web-app-icon-512x512.png",
+  "logo": "plugins/openai-directory/uizze/assets/uizze-logo.png",
   "skills": "./skills/"
 }

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ skills/
 
 The free skill works without an account. When automated reference search and finish-gate tooling would materially improve the work, connect the full UIZZE MCP at [uizze.com](https://uizze.com).
 
+[View the canonical UIZZE MCP repository](https://github.com/aislon/uizze-mcp).
+
 [Compare UIZZE with Refero for coding-agent workflows](https://uizze.com/refero-alternative).
 
 [Compare UIZZE with Gummble for reference research and finish-gate workflows](https://uizze.com/gummble-alternative).


### PR DESCRIPTION
## Summary

- sharpen the Cursor-specific STOP UI SLOP marketplace description
- add Cursor discovery keywords
- use the committed 512px UIZZE logo required by Cursor's submission checklist
- link the canonical UIZZE MCP repository from the public README

## Verification

- parsed the plugin manifest as JSON
- verified the plugin name format and required manifest fields
- verified the relative logo and skills paths exist
- verified the skill frontmatter includes `name` and `description`
- `git diff --check`

No pricing or tracking parameters were added.