### PR TITLE
Add skill-level MIT license

### DIFF
--- a/skills/anti-ui-slop/LICENSE
+++ b/skills/anti-ui-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 UIZZE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Add a skill-local copy of the repository MIT license to `skills/anti-ui-slop/`.

This keeps the skill's redistributable license alongside `SKILL.md`, which is required by skill directories that ingest or redistribute individual skill folders. The license is byte-for-byte identical to the repository root `LICENSE`; no runtime or skill behavior changes.

## Validation

- verified the two license files are byte-for-byte identical
- parsed all plugin JSON manifests and the skill YAML metadata
- scanned the repository for credential-shaped values
- `git diff --check`
