### PR TITLE
Add production skill install gate

### DIFF
--- a/.github/workflows/domain-skill-install.yml
+++ b/.github/workflows/domain-skill-install.yml
@@ -1,0 +1,53 @@
+name: Domain Skill Install
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/domain-skill-install.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/domain-skill-install.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - name: Install the public UIZZE skill
+        working-directory: ${{ runner.temp }}
+        run: >-
+          npx --yes skills@1.5.20 add https://uizze.com
+          --skill anti-ui-slop
+          --agent codex
+          --yes
+          --copy
+          --metadata '{"source":"uizze-publisher-ci","exclude_from_marketing_metrics":true}'
+
+      - name: Verify the installed skill
+        working-directory: ${{ runner.temp }}
+        shell: bash
+        run: |
+          skill=".agents/skills/anti-ui-slop/SKILL.md"
+          test -s "$skill"
+          grep -qx 'name: anti-ui-slop' "$skill"
+          grep -qx '# STOP UI SLOP.' "$skill"
+          grep -Fq 'https://uizze.com' "$skill"
+          if grep -Fq 'github.com' "$skill"; then
+            echo "The domain-backed skill must keep uizze.com as its public destination."
+            exit 1
+          fi


### PR DESCRIPTION
## What

- install `anti-ui-slop` from `https://uizze.com` with the current pinned Skills CLI
- verify the installed skill name, headline, and UIZZE destination
- run daily and whenever this gate changes
- identify publisher CI installs so they stay excluded from acquisition metrics

## Why

The domain-backed install command is a conversion path. This fails closed if discovery or the published artifact breaks.

## Validation

- clean local install with `skills@1.5.20` passed
- installed artifact checks passed
- YAML parse and `git diff --check` passed