### PR TITLE
Use Node 24 action runtime in install gate

### DIFF
--- a/.github/workflows/domain-skill-install.yml
+++ b/.github/workflows/domain-skill-install.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
 


### PR DESCRIPTION
Updates the production skill-install gate to the immutable `actions/setup-node@v6` commit so its daily run has no Node 20 action-runtime deprecation warning. No behavior or acquisition measurement changes.