### PR TITLE
Sharpen Cursor marketplace listing

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,12 +1,13 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.2.0",
-  "description": "Stop coding agents from shipping generic UI with UIZZE's 800,000+ real web and iOS screens and a hard finish gate.",
+  "version": "1.2.1",
+  "description": "If your UI screams AI, your app is dead. Give Cursor 800,000+ real screens to work from before it touches your frontend.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com"
   },
+  "publisher": "UIZZE",
   "homepage": "https://uizze.com",
   "repository": "https://github.com/uizze/uizze",
   "license": "MIT",


### PR DESCRIPTION
## What changed
- replaces the generic Cursor marketplace description with the approved direct hook
- explicitly identifies UIZZE as the publisher
- bumps the Cursor plugin manifest to 1.2.1

## Why
The Cursor listing should communicate the anti-slop value immediately while keeping the UIZZE organization identity, canonical homepage, and repository.

## Validation
- Cursor plugin manifest validates against the current official schema
- git diff --check passes
- homepage and approved README banner return HTTP 200