### PR TITLE
Prepare UIZZE skills for GitHub native discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ npx skills add https://uizze.com --skill anti-ui-slop
 
 [View the domain-backed skill on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop).
 
+### GitHub Copilot CLI
+
+```bash
+gh skill install uizze/uizze anti-ui-slop
+```
+
+This uses GitHub's native agent-skill workflow. The free skill gives Copilot the finish gate; connect the full UIZZE MCP only when live reference search and visual review would improve the work.
+
 ### Claude Code plugin
 
 ```text

--- a/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
+++ b/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use for web or iOS UI design, implementation, redesign, critique, and pre-ship review in Codex, Claude Code, Cursor, Copilot, and other coding agents.
+license: MIT
 ---
 
 > ***If your UI screams AI, your app is dead.***

--- a/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
+++ b/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use for web or iOS UI design, implementation, redesign, critique, and pre-ship review in Codex, Claude Code, Cursor, Copilot, and other coding agents.
+license: MIT
 ---
 
 > ***If your UI screams AI, your app is dead.***

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use for web or iOS UI design, implementation, redesign, critique, and pre-ship review in Codex, Claude Code, Cursor, Copilot, and other coding agents.
+license: MIT
 ---
 
 > ***If your UI screams AI, your app is dead.***


### PR DESCRIPTION
Adds the standard MIT license metadata to each synchronized UIZZE skill manifest. GitHub CLI native skill publishing now validates cleanly; this enables a canonical GitHub skill release without changing the skill workflow, public catalogue, or product claims.