### PR TITLE
Publish the free UI Slop Gate to the Official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,27 @@
+name: Publish UIZZE UI Slop Gate to MCP Registry
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out the canonical UIZZE manifest
+        uses: actions/checkout@v5
+
+      - name: Install the official MCP publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate with GitHub OIDC
+        working-directory: .mcp
+        run: ../mcp-publisher login github-oidc
+
+      - name: Publish the remote UIZZE UI Slop Gate
+        working-directory: .mcp
+        run: ../mcp-publisher publish

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.uizze/ui-slop-gate",
+  "title": "UIZZE UI Slop Gate",
+  "description": "Run a free UI Slop Gate against rendered HTML and CSS before a coding agent ships generic UI.",
+  "version": "1.2.4",
+  "repository": {
+    "id": "1301842069",
+    "source": "github",
+    "url": "https://github.com/uizze/uizze"
+  },
+  "websiteUrl": "https://uizze.com",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://uizze.com/mcp/preview"
+    }
+  ]
+}


### PR DESCRIPTION
## What this adds

- A validated remote-server manifest for the free UIZZE UI Slop Gate at `https://uizze.com/mcp/preview`.
- A manually triggered, GitHub OIDC publishing workflow for the Official MCP Registry.

## Why it matters

The free gate is a genuinely useful first experience: coding agents can check rendered HTML/CSS without an account, then reach full UIZZE only when live reference search and visual review are useful. The Official MCP Registry is a durable, high-intent discovery surface and is expected to feed downstream registry consumers.

## Guardrails

- The manifest points only to the public no-token preview, not the paid authenticated endpoint.
- Copy is factual: it describes generic-UI checks, not unsupported quality guarantees.
- Publishing is manual on purpose, so each registry version is reviewed before release.

## Validation

- Official Registry `POST /v0.1/validate`: `valid: true`, no issues.
- Live MCP `initialize` request to `/mcp/preview`: successful.
