### PR TITLE
Link the reproducible UI Slop Benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ codex mcp add uizze-preview --url https://uizze.com/mcp/preview
 
 This no-token preview exposes one deterministic `check_ui_slop` tool for rendered HTML and CSS. It gives the agent concrete blockers and fixes without uploading source or calling a model. [Use the full MCP setup](https://github.com/uizze/uizze-mcp#try-the-mcp-server-free) when you want the equivalent Claude Code or Cursor command.
 
+### Put it to a real test
+
+Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI Slop Benchmark](https://uizze.github.io/uizze-ui-slop-benchmark/): three fixed product tasks, identical prompts and starter states, and inspectable evidence for every awarded point.
+
 ### GitHub Copilot CLI
 
 ```bash


### PR DESCRIPTION
Adds one evidence-first cross-link from the canonical UIZZE skill README to the live, free benchmark Pages site.

This gives installers a choice between a quick UI Slop Gate review and a reproducible three-task evaluation, without adding pricing, tracking parameters, or another promotional directory link.
