### PR TITLE
Add GitHub Copilot plugin marketplace

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "uizze",
       "source": "./",
-      "description": "Give Cursor real screens to work from before it touches your frontend—and a hard finish gate before it ships."
+      "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate."
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.2.5",
-  "description": "If your UI screams AI, your app is dead. Give Cursor 800,000+ real screens to work from before it touches your frontend.",
+  "version": "1.2.6",
+  "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -13,22 +13,7 @@
       "name": "uizze",
       "source": "./",
       "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-      "version": "1.2.6",
-      "author": {
-        "name": "UIZZE",
-        "email": "business@uizze.com"
-      },
-      "homepage": "https://uizze.com",
-      "repository": "https://github.com/uizze/uizze",
-      "license": "MIT",
-      "keywords": [
-        "ui",
-        "design",
-        "frontend",
-        "anti-slop",
-        "agent-skill"
-      ],
-      "category": "Development"
+      "version": "1.2.6"
     }
   ]
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "uizze",
+  "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+  "version": "1.2.6",
+  "author": {
+    "name": "UIZZE",
+    "email": "business@uizze.com",
+    "url": "https://uizze.com"
+  },
+  "homepage": "https://uizze.com",
+  "repository": "https://github.com/uizze/uizze",
+  "license": "MIT",
+  "keywords": [
+    "ui",
+    "design",
+    "frontend",
+    "anti-slop",
+    "agent-skill"
+  ],
+  "category": "Developer Tools",
+  "skills": "./skills/",
+  "mcpServers": ".mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ This no-token preview exposes one deterministic `check_ui_slop` tool for rendere
 
 Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI Slop Benchmark](https://uizze.github.io/uizze-ui-slop-benchmark/): three fixed product tasks, identical prompts and starter states, and inspectable evidence for every awarded point.
 
-### GitHub Copilot CLI
+### GitHub Copilot CLI plugin
 
 ```bash
-gh skill install uizze/uizze anti-ui-slop
+copilot plugin marketplace add uizze/uizze
+copilot plugin install uizze@uizze
 ```
 
-This uses GitHub's native agent-skill workflow. The free skill gives Copilot the finish gate; connect the full UIZZE MCP only when live reference search and visual review would improve the work.
+This uses Copilot CLI's native plugin marketplace. It installs the free UIZZE workflow and the no-token UI Slop Gate preview; use the full [UIZZE MCP](https://uizze.com) only when live reference search and visual review would improve the work.
 
 ### Score a rendered screen
 


### PR DESCRIPTION
## What changed

- Adds the canonical `.github/plugin/marketplace.json` required for GitHub Copilot CLI discovery.
- Documents the official two-command Copilot CLI install path.
- Aligns Cursor, Claude, and Codex plugin positioning with UIZZE’s approved message.

## Why

UIZZE can now be registered as a native Copilot CLI marketplace rather than relying on Claude-specific manifest discovery or an unrelated `gh skill` command.

## Validation

- Parsed all marketplace/plugin JSON manifests.
- Verified the Copilot marketplace owner, plugin source, skills root, and exact shared positioning.
- Ran `git diff --check`.