### PR TITLE
Use distinct Copilot plugin name

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-    "version": "1.2.6"
+    "version": "1.2.7"
   },
   "plugins": [
     {
-      "name": "uizze",
+      "name": "uizze-ui-slop",
       "source": "./",
       "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-      "version": "1.2.6"
+      "version": "1.2.7"
     }
   ]
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "uizze",
+  "name": "uizze-ui-slop",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI
 
 ```bash
 copilot plugin marketplace add uizze/uizze
-copilot plugin install uizze@uizze
+copilot plugin install uizze-ui-slop@uizze
 ```
 
 This uses Copilot CLI's native plugin marketplace. It installs the free UIZZE workflow and the no-token UI Slop Gate preview; use the full [UIZZE MCP](https://uizze.com) only when live reference search and visual review would improve the work.


### PR DESCRIPTION
## What changed

- Renames the canonical Copilot plugin to `uizze-ui-slop`.
- Updates the Copilot marketplace entry and install command.
- Bumps the canonical Copilot plugin to 1.2.7.

## Why

GitHub’s default Awesome Copilot marketplace already has a local `uizze` plugin. A distinct technical plugin id prevents a name collision while preserving the UIZZE brand and marketplace name.

## Validation

- Parsed the canonical Copilot plugin and marketplace JSON.
- Verified plugin name/version match, referenced skills and MCP config paths, and the canonical install command.
- Ran `git diff --check`.