### PR TITLE
Fix UIZZE installation paths and add Kiro Power

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-    "version": "1.2.6"
+    "version": "1.2.7"
   },
   "plugins": [
     {
-      "name": "uizze",
+      "name": "uizze-ui-slop",
       "source": "./",
       "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-      "version": "1.2.6"
+      "version": "1.2.7"
     }
   ]
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "uizze",
+  "name": "uizze-ui-slop",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI
 
 ```bash
 copilot plugin marketplace add uizze/uizze
-copilot plugin install uizze@uizze
+copilot plugin install uizze-ui-slop@uizze
 ```
 
 This uses Copilot CLI's native plugin marketplace. It installs the free UIZZE workflow and the no-token UI Slop Gate preview; use the full [UIZZE MCP](https://uizze.com) only when live reference search and visual review would improve the work.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This no-token preview exposes one deterministic `check_ui_slop` tool for rendere
 
 ### Put it to a real test
 
-Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI Slop Benchmark](https://uizze.github.io/uizze-ui-slop-benchmark/): three fixed product tasks, identical prompts and starter states, and inspectable evidence for every awarded point.
+Want an evidence-only answer instead of a one-off review? Run the free [UIZZE UI Slop Benchmark](https://uizze.github.io/uizze-ui-slop-benchmark/): a fixed product task, identical prompts and starter states, and inspectable evidence for every awarded point.
 
 ### GitHub Copilot CLI plugin
 
@@ -48,7 +48,7 @@ This uses Copilot CLI's native plugin marketplace. It installs the free UIZZE wo
 ### Score a rendered screen
 
 ```bash
-gh skill install uizze/uizze ui-slop-score
+npx skills add https://uizze.com --skill ui-slop-score
 ```
 
 Use the free `ui-slop-score` skill when a screen needs an honest pre-merge visual review. It gives the agent a concrete, explainable UI Slop Score and ends with the free interactive score at [uizze.com/tools/ui-slop-score](https://uizze.com/tools/ui-slop-score).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Use the free `ui-slop-score` skill when a screen needs an honest pre-merge visua
 /plugin install uizze@uizze
 ```
 
+### Kiro Power
+
+In Kiro, open **Powers** → **Add Custom Power** → **Import power from GitHub**, then enter:
+
+```text
+https://github.com/uizze/kiro-ui-slop-power
+```
+
+The [UIZZE UI Slop Finish Gate for Kiro](https://github.com/uizze/kiro-ui-slop-power) loads only for relevant UI work and connects the full UIZZE MCP through Kiro's normal authentication flow.
+
 ### Codex plugin marketplace
 
 ```bash


### PR DESCRIPTION
## What changed
- use the verified domain-backed skills CLI command for the free UI Slop Score
- keep the Copilot plugin identifier distinct from the UIZZE marketplace
- document the new native Kiro Power install path
- align the benchmark copy with the currently published fixed task

## Why
Visitors should be able to install the free UIZZE workflow from the public README using working, native paths for their coding agent.

## Validation
- `git diff --check`
- verified the live `https://uizze.com/.well-known/agent-skills/index.json` advertises `ui-slop-score`
- verified `https://uizze.com/tools/ui-slop-score` returns HTTP 200
- verified the public Kiro Power has a valid `mcp.json` and UIZZE publishes its OAuth protected-resource metadata