### PR TITLE
Track Frontend Development Bookmarks submission

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -81,6 +81,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Agent Skills directory PR: https://github.com/VoltAgent/awesome-agent-skills/pull/911
 - Design tools directory PR: https://github.com/goabstract/Awesome-Design-Tools/pull/586
 - Awesome Design Systems resource PR: https://github.com/klaufel/awesome-design-systems/pull/32
+- Frontend Development Bookmarks PR: https://github.com/dypsilon/frontend-dev-bookmarks/pull/528
 - Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420
 - Skillmatic Agent Skills PR: https://github.com/skillmatic-ai/awesome-agent-skills/pull/153
 - SkillCreator Agent Skills PR: https://github.com/skillcreatorai/Awesome-Agent-Skills/pull/10


### PR DESCRIPTION
Add the Frontend Development Bookmarks PR to the canonical distribution map so the submission and its status remain discoverable from one source.