### PR TITLE
Add canonical Glama claim metadata

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -46,7 +46,7 @@ Use “800,000+ real web and iOS screens” in public copy. Keep the free anti-u
 
 Update existing entries first:
 
-- Glama: https://glama.ai/mcp/servers/uizze/uizze-mcp
+- Glama: https://glama.ai/mcp/servers/uizze/uizze-mcp (legacy record points to retired `uizze/uizze-mcp`; root `glama.json` is now present in the canonical repository for a fresh claim/index pass)
 - PulseMCP: https://www.pulsemcp.com/servers/uizze
 - MCP Market: https://mcpmarket.com/server/uizze-1
 - MCPServers.org: https://mcpservers.org/servers/uizze-com
@@ -55,7 +55,7 @@ Submit the canonical repository next:
 
 - Smithery: https://smithery.ai/servers?q=uizze
 - MCP.so: https://mcp.so/submit?type=server
-- Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score, while UIZZE currently has a hosted connector listing)
+- Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
 - Awesome Claude Plugins: https://github.com/composio-community/awesome-claude-plugins
 - Official Cursor plugins: https://github.com/cursor/plugins
 - Awesome Cursor Rules: https://github.com/PatrickJS/awesome-cursorrules

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -82,6 +82,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Design tools directory PR: https://github.com/goabstract/Awesome-Design-Tools/pull/586
 - Awesome Design Systems resource PR: https://github.com/klaufel/awesome-design-systems/pull/32
 - Frontend Development Bookmarks PR: https://github.com/dypsilon/frontend-dev-bookmarks/pull/528
+- Awesome Web Design inspiration PR: https://github.com/nicolesaidy/awesome-web-design/pull/71
 - Meng To design skills PR: https://github.com/MengTo/Skills/pull/7
 - Tech Leads Club Agent Skills intake issue: https://github.com/tech-leads-club/agent-skills/issues/167
 - Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["uizze"]
+}


### PR DESCRIPTION
Add the root glama.json required for organization-owned server listings and document the legacy Glama record mismatch in the distribution map. This keeps the canonical repository eligible for a fresh Glama claim/index pass without exposing credentials or changing the live MCP contract.