### PR TITLE
Track MCP directory distribution

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -58,6 +58,7 @@ Submit the canonical repository next:
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
 - TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
 - YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (issue #420 requests a canonical UIZZE entry in the active Community Servers list)
+- libukai Awesome Agent Skills: https://github.com/libukai/awesome-agent-skills (issue #128 recommends the portable anti-ui-slop Skill for the curated programming/design section)
 - Awesome Claude Plugins: https://github.com/composio-community/awesome-claude-plugins
 - Official Cursor plugins: https://github.com/cursor/plugins
 - Awesome Cursor Rules: https://github.com/PatrickJS/awesome-cursorrules

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -56,6 +56,7 @@ Submit the canonical repository next:
 - Smithery: https://smithery.ai/servers?q=uizze
 - MCP.so: https://mcp.so/submit?type=server
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
+- TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
 - Awesome Claude Plugins: https://github.com/composio-community/awesome-claude-plugins
 - Official Cursor plugins: https://github.com/cursor/plugins
 - Awesome Cursor Rules: https://github.com/PatrickJS/awesome-cursorrules

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -59,6 +59,7 @@ Submit the canonical repository next:
 - TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
 - YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (issue #420 requests a canonical UIZZE entry in the active Community Servers list)
 - libukai Awesome Agent Skills: https://github.com/libukai/awesome-agent-skills (issue #128 recommends the portable anti-ui-slop Skill for the curated programming/design section)
+- futantan Agent Skills Explorer: https://github.com/futantan/agent-skills.md (issue #24 requests indexing the canonical anti-ui-slop Skill)
 - Awesome Claude Plugins: https://github.com/composio-community/awesome-claude-plugins
 - Official Cursor plugins: https://github.com/cursor/plugins
 - Awesome Cursor Rules: https://github.com/PatrickJS/awesome-cursorrules

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -57,6 +57,7 @@ Submit the canonical repository next:
 - MCP.so: https://mcp.so/submit?type=server
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
 - TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
+- YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (issue #420 requests a canonical UIZZE entry in the active Community Servers list)
 - Awesome Claude Plugins: https://github.com/composio-community/awesome-claude-plugins
 - Official Cursor plugins: https://github.com/cursor/plugins
 - Awesome Cursor Rules: https://github.com/PatrickJS/awesome-cursorrules


### PR DESCRIPTION
Update the canonical distribution map with four current GitHub discovery actions:

- TensorBlock MCP Index PR #1777 corrects the live UIZZE profile from the retired aislon/uizze-mcp URL to uizze/uizze while preserving the stable profile link.
- YuzeHao2023/Awesome-MCP-Servers issue #420 requests a canonical UIZZE entry in its active Community Servers list.
- libukai/awesome-agent-skills issue #128 recommends the anti-ui-slop Skill in its curated programming/design section.
- futantan/agent-skills.md issue #24 requests indexing the canonical anti-ui-slop Skill in its public explorer.

All new submissions use the current anti-UI-slop positioning, the 800,000+ real web and iOS screens claim, and the canonical uizze/uizze repository rule.