### PR TITLE
Track MCP.so listing repair

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -54,7 +54,7 @@ Update existing entries first:
 Submit the canonical repository next:
 
 - Smithery: https://smithery.ai/servers?q=uizze
-- MCP.so: https://mcp.so/submit?type=server
+- MCP.so: https://mcp.so/submit?type=server (existing GitHub intake issue #3117 was reopened with the canonical `uizze/uizze` source and current anti-UI-slop copy)
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
 - TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
 - YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (issue #420 requests a canonical UIZZE entry in the active Community Servers list)


### PR DESCRIPTION
Update the centralized distribution map with the repaired MCP.so intake. Existing issue #3117 was reopened and corrected from the retired aislon/uizze-mcp source to the canonical uizze/uizze repository, with the current anti-UI-slop and 800,000+ screens positioning.