### PR TITLE
Mark TensorBlock directory listing deployed

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -56,7 +56,7 @@ Submit the canonical repository next:
 - Smithery: https://smithery.ai/servers?q=uizze
 - MCP.so: https://mcp.so/submit?type=server (existing GitHub intake issue #3117 was reopened with the canonical `uizze/uizze` source and current anti-UI-slop copy)
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; maintainer requires a Glama server quality score; the current Glama connector is separate from the legacy server record)
-- TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 corrects the existing UIZZE profile from the retired repository URL to `uizze/uizze` while preserving its stable profile link)
+- TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 merged and deployed; live profile is https://tensorblock.co/mcp/servers/github-uizze-uizze-2a597cfa with canonical `uizze/uizze` metadata)
 - appcypher Awesome MCP Servers: https://github.com/appcypher/awesome-mcp-servers (archived/read-only upstream; a prepared fork cannot become a live directory PR)
 - YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (issue #420 requests a canonical UIZZE entry in the active Community Servers list)
 - libukai Awesome Agent Skills: https://github.com/libukai/awesome-agent-skills (issue #128 recommends the portable anti-ui-slop Skill for the curated programming/design section)


### PR DESCRIPTION
Update the distribution map with the merged TensorBlock PR #1777 and its verified live UIZZE profile. The deployed API now returns the canonical repository and current anti-UI-slop copy.