### PR TITLE
Track GitHub Copilot distribution follow-up

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -133,5 +133,6 @@ Already listed:
 
 - GitHub MCP Registry: https://github.com/mcp/uizze/uizze (official registry is active at `io.github.uizze/uizze`, latest `v1.2.9`, with the canonical repository URL; older retired-repository records are deprecated)
 - GitHub Awesome Copilot skill: https://github.com/github/awesome-copilot/blob/main/skills/anti-ui-slop/SKILL.md
+- GitHub Awesome Copilot follow-up PR: https://github.com/github/awesome-copilot/pull/2685 (documents the separate anonymous `check_ui_slop` preview; all automated checks pass, maintainer review pending)
 - skills.sh: https://www.skills.sh/site/uizze.com/anti-ui-slop
 - Chat2AnyLLM source hub: https://github.com/Chat2AnyLLM/awesome-repo-configs/pull/144 (plugin source entry merged and live); its downstream README now lists `uizze/uizze` as a healthy `.claude-plugin` marketplace source after https://github.com/Chat2AnyLLM/awesome-repo-configs/pull/146 quarantined the malformed source that blocked generation (related maintainer issue: https://github.com/Chat2AnyLLM/awesome-claude-plugins/issues/50); MCP source follow-up: https://github.com/Chat2AnyLLM/awesome-repo-configs/pull/145, with the missing review trigger tracked in https://github.com/Chat2AnyLLM/awesome-repo-configs/pull/147


### PR DESCRIPTION
Record the official GitHub Copilot follow-up PR that documents the separate anonymous `check_ui_slop` preview endpoint. Its automated validation is green and maintainer review remains pending. This keeps the canonical distribution map current and prevents the follow-up from disappearing from the queue.