### PR TITLE
Track ChatGPT repositories distribution PR

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -132,6 +132,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Awesome Vibe Coding (filipecalegario) PR: https://github.com/filipecalegario/awesome-vibe-coding/pull/290 (UIZZE entry in Plugins and Extensions)
 - Awesome OpenCode PR: https://github.com/awesome-opencode/awesome-opencode/pull/609 (UIZZE project entry for OpenCode's MCP workflow)
 - Awesome MCP ZH PR: https://github.com/yzfly/Awesome-MCP-ZH/pull/463 (Chinese-language MCP directory entry for the free UI slop preview)
+- Awesome ChatGPT Repositories PR: https://github.com/taishi-i/awesome-ChatGPT-repositories/pull/209 (UIZZE anti-UI-slop toolkit entry for coding agents)
 - Claude Code Everything guide PR: https://github.com/wesammustafa/Claude-Code-Everything-You-Need-to-Know/pull/30 (adds UIZZE to the quality, review, and debugging skill table)
 - LangGPT Awesome Claude Code PR: https://github.com/LangGPT/awesome-claude-code/pull/121
 - Chinese Awesome Claude Skills PR: https://github.com/shishirui/awesome-claude-skills-zh/pull/10


### PR DESCRIPTION
Updates the canonical distribution map with the new UIZZE listing PR:

- https://github.com/taishi-i/awesome-ChatGPT-repositories/pull/209
- UIZZE is listed as an anti-UI-slop toolkit for Codex, Claude Code, Cursor, and Copilot
- public copy uses the canonical 800,000+ real web and iOS screens claim

No product code or credentials changed.