### PR TITLE
Point map to OpenClaw distribution update

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -88,7 +88,7 @@ Keep these surfaces aligned with the canonical copy above:
 
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044287
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044327
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest
 - GitHub Action directory PR: https://github.com/sdras/awesome-actions/pull/899
 - Claude Code plugins directory PR: https://github.com/ccplugins/awesome-claude-code-plugins/pull/350


### PR DESCRIPTION
Points the canonical distribution map to the latest public discussion update for the OpenClaw submission:

https://github.com/uizze/uizze/discussions/44#discussioncomment-18044327

No product code or credentials changed.