### PR TITLE
Fix domain-backed Skill parity at EOF

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -88,7 +88,7 @@ Keep these surfaces aligned with the canonical copy above:
 
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044287
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044327
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest
 - GitHub Action directory PR: https://github.com/sdras/awesome-actions/pull/899
 - Claude Code plugins directory PR: https://github.com/ccplugins/awesome-claude-code-plugins/pull/350

--- a/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
+++ b/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
@@ -123,3 +123,4 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
+

--- a/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
+++ b/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
@@ -123,3 +123,4 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
+

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -123,3 +123,4 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
+


### PR DESCRIPTION
The live domain-backed anti-ui-slop Skill contains the generated body with two trailing newline bytes, while the three checked-in public copies had one.

This makes Domain Skill Install fail at the final cmp even though the content is otherwise identical. Add the missing newline to:
- skills/anti-ui-slop/SKILL.md
- plugins/claude-directory/skills/anti-ui-slop/SKILL.md
- plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md

Validation: local byte-for-byte cmp against a fresh `npx skills@1.5.20 add https://uizze.com --skill anti-ui-slop` install.