### PR TITLE
Point map at latest workflow update

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -93,7 +93,7 @@ Keep these surfaces aligned with the canonical copy above:
 
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044582
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18044643
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest
 - GitHub Action directory PR: https://github.com/sdras/awesome-actions/pull/899
 - Claude Code plugins directory PR: https://github.com/ccplugins/awesome-claude-code-plugins/pull/350


### PR DESCRIPTION
## Summary
- point the canonical distribution map at the latest launch discussion update
- keep public distribution tracking aligned with the merged README workflow explanation

## Verification
- `git diff --check`
