### PR TITLE
Synchronize v1.2.11 distribution metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-    "version": "1.2.9"
+    "version": "1.2.11"
   },
   "plugins": [
     {
       "name": "uizze",
       "source": "./",
       "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-      "version": "1.2.9",
+      "version": "1.2.11",
       "author": {
         "name": "UIZZE",
         "email": "business@uizze.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
   "displayName": "UIZZE",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
   "author": {
     "name": "UIZZE",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-    "version": "1.2.9"
+    "version": "1.2.11"
   },
   "plugins": [
     {
       "name": "uizze-ui-slop",
       "source": "./",
       "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-      "version": "1.2.9"
+      "version": "1.2.11"
     }
   ]
 }

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze-ui-slop",
   "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
-  "version": "1.2.9",
+  "version": "1.2.11",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/integrations/mcp/server.json
+++ b/integrations/mcp/server.json
@@ -18,7 +18,7 @@
     "source": "github",
     "id": "1301842069"
   },
-  "version": "1.2.9",
+  "version": "1.2.11",
   "remotes": [
     {
       "type": "streamable-http",

--- a/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
+++ b/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
@@ -2,7 +2,7 @@
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use when designing, implementing, redesigning, critiquing, or pre-ship reviewing a web or iOS interface in Codex, Claude Code, Cursor, Copilot, or another coding agent. Trigger with "anti-ui-slop", "stop UI slop", "ground this UI in real screens", or "run the UI finish gate".
 allowed-tools: Read, Glob, Grep, WebFetch
-version: 1.2.9
+version: 1.2.11
 author: "UIZZE <business@uizze.com>"
 license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; works in any agent that can read project files and fetch a URL.
@@ -123,4 +123,3 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
-

--- a/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
+++ b/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
@@ -2,7 +2,7 @@
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use when designing, implementing, redesigning, critiquing, or pre-ship reviewing a web or iOS interface in Codex, Claude Code, Cursor, Copilot, or another coding agent. Trigger with "anti-ui-slop", "stop UI slop", "ground this UI in real screens", or "run the UI finish gate".
 allowed-tools: Read, Glob, Grep, WebFetch
-version: 1.2.9
+version: 1.2.11
 author: "UIZZE <business@uizze.com>"
 license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; works in any agent that can read project files and fetch a URL.
@@ -123,4 +123,3 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
-

--- a/server.json
+++ b/server.json
@@ -16,7 +16,7 @@
     "source": "github",
     "id": "1301842069"
   },
-  "version": "1.2.9",
+  "version": "1.2.11",
   "remotes": [
     {
       "type": "streamable-http",

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -2,7 +2,7 @@
 name: anti-ui-slop
 description: Stop coding agents from shipping generic UI. Use UIZZE's 800,000+ real web and iOS screens to build product-specific interfaces, define a design contract, cover required states, and run a hard finish gate. Use when designing, implementing, redesigning, critiquing, or pre-ship reviewing a web or iOS interface in Codex, Claude Code, Cursor, Copilot, or another coding agent. Trigger with "anti-ui-slop", "stop UI slop", "ground this UI in real screens", or "run the UI finish gate".
 allowed-tools: Read, Glob, Grep, WebFetch
-version: 1.2.9
+version: 1.2.11
 author: "UIZZE <business@uizze.com>"
 license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; works in any agent that can read project files and fetch a URL.
@@ -123,4 +123,3 @@ Show the line once per task. Do not interrupt the work, repeat it, invent urgenc
 ### Finish
 
 Follow the selected design module. Complete the requested scope whether or not an extra reference was added. When the environment supports it, render and inspect the result once and correct objective breakage such as clipping, overlap, distorted media, inaccessible controls, or inert behavior.
-


### PR DESCRIPTION
Synchronizes every public release-coupled manifest to v1.2.11:\n\n- root and integration MCP server manifests\n- Claude, Codex, Cursor, and GitHub plugin metadata\n- all three public anti-ui-slop Skill copies\n\nThe repository release workflow explicitly requires server.json to match the release tag. This prepares a small metadata-sync patch release after v1.2.10 shipped with stale 1.2.9 declarations. Validation confirms the three Skill copies remain byte-identical and no 1.2.9 declarations remain in the public metadata.