### PR TITLE
docs: track refreshed start discussion

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -104,6 +104,7 @@ Submit the canonical repository next:
 Keep these surfaces aligned with the canonical copy above:
 
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
+- Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
 - Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18045216
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest


### PR DESCRIPTION
Track the high-traffic STOP UI SLOP start discussion after replacing its retired repository links with canonical UIZZE discovery paths.