### PR TITLE
docs: track remote MCP listing refresh

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -60,6 +60,7 @@ Submit the canonical repository next:
 - Official Claude Plugins Directory: https://github.com/anthropics/claude-plugins-official (Anthropic's actively maintained 33,000+ star marketplace accepts third-party plugins through the official submission form at https://clau.de/plugin-directory-submission; UIZZE is not listed yet and this intake does not use GitHub pull requests)
 - Smithery: https://smithery.ai/servers?q=uizze
 - MCP.so: https://mcp.so/submit?type=server (existing GitHub intake issue #3117 was reopened with the canonical `uizze/uizze` source and current anti-UI-slop copy)
+- Awesome Remote MCP Servers: https://github.com/jaw9c/awesome-remote-mcp-servers (PR #627 refreshes the existing UIZZE row to the free, no-account `https://uizze.com/mcp/preview` endpoint; broken PR #502 was closed after GitHub renamed its fork)
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; live preview endpoint and canonical Glama connector evidence were posted, but the maintainer still requires a Glama source-server quality score)
 - TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 merged and deployed; live profile is https://tensorblock.co/mcp/servers/github-uizze-uizze-2a597cfa with canonical `uizze/uizze` metadata)
 - appcypher Awesome MCP Servers: https://github.com/appcypher/awesome-mcp-servers (archived/read-only upstream; a prepared fork cannot become a live directory PR)
@@ -132,6 +133,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Requestly Awesome Frontend Resources PR: https://github.com/requestly/awesome-frontend-resources/pull/33 (free-first UIZZE entry in Some Awesome Projects)
 - Web Development Resources PR: https://github.com/markodenic/web-development-resources/pull/813
 - Awesome MCP Servers PR: https://github.com/punkpeye/awesome-mcp-servers/pull/10946
+- Awesome Remote MCP Servers PR: https://github.com/jaw9c/awesome-remote-mcp-servers/pull/627 (refreshes the existing UIZZE row to the free preview and canonical repository; supersedes broken PR #502)
 - Awesome Codex CLI PR: https://github.com/RoggeOhta/awesome-codex-cli/pull/207 (direct Codex CLI Specialized Skills listing with the free-first anti-UI-slop and preview paths; review pending)
 - MobinX Awesome MCP List PR: https://github.com/MobinX/awesome-mcp-list/pull/387 (Developer Tools listing with the canonical source and current 800,000+ positioning; review pending)
 - Cline official MCP Marketplace submission: https://github.com/cline/mcp-marketplace/issues/2082


### PR DESCRIPTION
## Summary

- add Awesome Remote MCP Servers to the canonical distribution queue
- track the corrected free preview endpoint and canonical repository
- record the broken fork-renamed PR cleanup

## Verification

- Current upstream submission: https://github.com/jaw9c/awesome-remote-mcp-servers/pull/627
- Preview MCP `tools/list` exposes `check_ui_slop`
- The stale duplicate PR #502 is closed

This change updates distribution tracking only.