### PR TITLE
docs: track action metadata update

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -117,6 +117,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Claude Code Frontend Design Toolkit PR: https://github.com/wilwaldon/Claude-Code-Frontend-Design-Toolkit/pull/5 (README source repaired to the canonical `uizze/uizze` repository; checks are clean)
 - Awesome Vibe Coding documentation PR: https://github.com/filipecalegario/awesome-vibe-coding/pull/257 (visible entry now leads with the free Skill and deterministic preview, then distinguishes full UIZZE and its 800,000+ real web and iOS screens)
 - GitHub Action directory PR: https://github.com/sdras/awesome-actions/pull/899 (visible entry now includes the 800,000+ provenance while keeping the Action itself a focused local source check)
+- GitHub Action metadata PR: https://github.com/uizze/uizze/pull/144 (merged; root Action metadata now uses a concrete searchable description for generic UI, missing states, inert controls, and token drift)
 - Claude Code plugins directory PR: https://github.com/ccplugins/awesome-claude-code-plugins/pull/350
 - Agent Skills directory PR: https://github.com/VoltAgent/awesome-agent-skills/pull/911 (visible entry now identifies the free Skill and its 800,000+ real web and iOS screen grounding)
 - Design tools directory PR: https://github.com/goabstract/Awesome-Design-Tools/pull/586


### PR DESCRIPTION
Record the merged Action metadata update in the public distribution map.

The root action.yml description now makes the free Action and its concrete UI checks searchable, while Marketplace publication remains a separate authenticated release-form step.