### PR TITLE
docs: record verified Glama connector

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -47,7 +47,7 @@ Use “800,000+ real web and iOS screens” in public copy. Keep the free anti-u
 
 Update existing entries first:
 
-- Glama connector: https://glama.ai/mcp/connectors/io.github.uizze/uizze (canonical hosted record now points to `https://uizze.com/mcp/preview` and reports 4.3/5 across one tool; the separate server record at https://glama.ai/mcp/servers/uizze/uizze-mcp still points to retired `uizze/uizze-mcp` and has no score)
+- Glama connector: https://glama.ai/mcp/connectors/io.github.uizze/uizze (canonical hosted record is now verified, has a healthy `glama.json`, points to `https://uizze.com/mcp/preview`, and reports 4.3/5 across one tool; the separate server record at https://glama.ai/mcp/servers/uizze/uizze-mcp still points to retired `uizze/uizze-mcp` and has no score)
 - PulseMCP: https://www.pulsemcp.com/servers/uizze
 - MCP Market: https://mcpmarket.com/server/uizze-1
 - MCPServers.org: https://mcpservers.org/servers/uizze-com (live listing verified with the current 800,000+ positioning and uizze.com link)


### PR DESCRIPTION
Update DISTRIBUTION.md with the current Glama state.

The canonical connector now reports a healthy glama.json and verified ownership, while the separate retired uizze/uizze-mcp server record remains explicitly documented as unresolved.