### PR TITLE
docs: refresh Tech Leads Club intake status

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -126,7 +126,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Frontend Development Bookmarks PR: https://github.com/dypsilon/frontend-dev-bookmarks/pull/528
 - Awesome Web Design inspiration PR: https://github.com/nicolesaidy/awesome-web-design/pull/71
 - Meng To design skills PR: https://github.com/MengTo/Skills/pull/7
-- Tech Leads Club Agent Skills intake issue: https://github.com/tech-leads-club/agent-skills/issues/167
+- Tech Leads Club Agent Skills intake issue: https://github.com/tech-leads-club/agent-skills/issues/167 (issue refreshed with v1.2.11, current free preview, 800,000+ evidence, and passing HOL Plugin Scanner status)
 - Awesome Hermes Agent recommendation issue: https://github.com/0xNyk/awesome-hermes-agent/issues/325 (portable anti-UI-slop skill recommendation for the agentskills.io ecosystem)
 - Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420
 - Skillmatic Agent Skills PR: https://github.com/skillmatic-ai/awesome-agent-skills/pull/153


### PR DESCRIPTION
Refresh the canonical map entry for the Tech Leads Club Agent Skills issue after updating the maintainer-facing proposal with current release, preview, evidence, and scanner details.

Documentation-only change.