### PR TITLE
docs: record retired repository redirect

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -37,7 +37,7 @@ The free skill runs locally without an account. Connect the free preview MCP for
 
 ## Canonical repository rule
 
-Use `https://github.com/uizze/uizze` for every new listing. Treat `uizze/uizze-mcp`, `aislon/uizze-mcp`, and `samuelbushi/uizze-mcp` as retired distribution URLs. Update or remove those entries instead of creating another duplicate.
+Use `https://github.com/uizze/uizze` for every new listing. Treat `uizze/uizze-mcp`, `aislon/uizze-mcp`, and `samuelbushi/uizze-mcp` as retired distribution URLs. The personal archive at `samuelbushi/uizze-mcp` is now archived with a repository-level redirect and deprecation README. Update or remove those entries instead of creating another duplicate.
 
 ## Claim rule
 


### PR DESCRIPTION
## Summary

- document the retired `samuelbushi/uizze-mcp` archive cleanup
- keep future distribution work pointed at the canonical `uizze/uizze` repository

The retired repository is archived, its description and homepage point to the canonical source, and its README now redirects visitors to the current Skill, preview, MCP, and Registry links.

## Verification

- `git diff --check`
- tracked JSON validation
- confirmed the canonical map contains the retired repository guard

This is a distribution-documentation update only.