### PR TITLE
docs: expose GitHub discovery paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,11 @@ It does not copy another product's branding, proprietary text, imagery, or exact
 ## Distribution
 
 Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install language, and directory links.
+
+## Find UIZZE on GitHub
+
+- [Official MCP Registry record](https://github.com/mcp/uizze/uizze)
+- [GitHub Copilot anti-ui-slop Skill](https://github.com/github/awesome-copilot/tree/main/skills/anti-ui-slop)
+- [UIZZE organization profile](https://github.com/uizze)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18046566)
+- [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary

Add a compact “Find UIZZE on GitHub” section to the canonical README. It links the official MCP Registry record, the merged GitHub Copilot Skill, the UIZZE organization profile, the latest distribution discussion, and the full distribution map.

This turns the repository landing page into a direct discovery hub while keeping pending third-party submissions in `DISTRIBUTION.md`.

## Verification

- `git diff --check`
- all five public links returned HTTP 200
- tracked JSON and Skill parity checks
- GitHub Action tests and packaged-runtime validation
- benchmark tests
- finish-gate tests