### PR TITLE
docs: document current Glama submission route

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -48,6 +48,7 @@ Use “800,000+ real web and iOS screens” in public copy. Keep the free anti-u
 Update existing entries first:
 
 - Glama connector: https://glama.ai/mcp/connectors/io.github.uizze/uizze (canonical hosted record is now verified, has a healthy `glama.json`, points to `https://uizze.com/mcp/preview`, and reports 4.3/5 across one tool; the separate server record at https://glama.ai/mcp/servers/uizze/uizze-mcp still points to retired `uizze/uizze-mcp` and has no score)
+- Glama source-server submission: https://glama.ai/mcp/servers (use **Add Server** → **Server** and submit `https://github.com/uizze/uizze`; the current `/api/mcp/servers/submit` endpoint redirects unauthenticated visitors to sign-up, so the canonical source-server listing and score remain externally gated; do not restore the retired repository)
 - PulseMCP: https://www.pulsemcp.com/servers/uizze
 - MCP Market: https://mcpmarket.com/server/uizze-1
 - MCPServers.org: https://mcpservers.org/servers/uizze-com (live listing verified with the current 800,000+ positioning and uizze.com link)
@@ -224,7 +225,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Chinese Awesome Claude Skills PR: https://github.com/shishirui/awesome-claude-skills-zh/pull/10
 - KaranB192 Awesome Claude Skills PR: https://github.com/karanb192/awesome-claude-skills/pull/162
 
-Marketplace status: `v1.2.11` is the current release with valid root Action metadata and the aligned `v1` tag, but its GitHub Marketplace publish checkbox remains unsubmitted. Marketplace search still returns zero public results; an earlier category-save attempt returned a GitHub 500, and the authenticated release form still requires the final publish action.
+Marketplace status: `v1.2.11` is the current release with valid root Action metadata and the aligned `v1` tag, but its GitHub Marketplace publish checkbox remains unsubmitted. Marketplace search still returns zero public results; an earlier category-save attempt returned a GitHub 500, and the authenticated release form still requires the final publish action. GitHub’s public REST and GraphQL APIs expose no supported Marketplace publish mutation, so this remains a release-form action.
 
 Already listed:
 

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -66,7 +66,7 @@ Submit the canonical repository next:
 - Hosted & Managed MCP Servers: https://github.com/sylviangth/awesome-remote-mcp-servers (separate 65-star directory; PR #64 now uses the free preview and canonical UIZZE copy, with maintainer review pending)
 - Awesome MCP Servers: https://github.com/punkpeye/awesome-mcp-servers (PR #10946 is open; live preview endpoint and canonical Glama connector evidence were posted, but the maintainer still requires a Glama source-server quality score)
 - mctrinh Awesome MCP Servers: https://github.com/mctrinh/awesome-mcp-servers (PR #82 repairs an open listing that still referenced retired `uizze/uizze-mcp`; the branch now uses `uizze/uizze` and the free preview, with maintainer review pending)
-- TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers (PR #1777 merged and deployed; live profile is https://tensorblock.co/mcp/servers/github-uizze-uizze-2a597cfa with canonical `uizze/uizze` metadata)
+- TensorBlock MCP Index: https://github.com/TensorBlock/awesome-mcp-servers ([PR #1777](https://github.com/TensorBlock/awesome-mcp-servers/pull/1777) merged and deployed; live profile is https://tensorblock.co/mcp/servers/github-uizze-uizze-2a597cfa with canonical `uizze/uizze` metadata)
 - appcypher Awesome MCP Servers: https://github.com/appcypher/awesome-mcp-servers (archived/read-only upstream; a prepared fork cannot become a live directory PR)
 - YuzeHao2023 Awesome MCP Servers: https://github.com/YuzeHao2023/Awesome-MCP-Servers (PR #369 adds the canonical UIZZE entry to the active Community Servers list; issue #420 is the original intake request)
 - adw0rd Awesome MCP Servers: https://github.com/adw0rd/awesome-mcp-servers/issues/16 (canonical-source correction posted; original issue body still needs maintainer-side replacement)
@@ -146,6 +146,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Meng To design skills PR: https://github.com/MengTo/Skills/pull/7
 - Tech Leads Club Agent Skills intake issue: https://github.com/tech-leads-club/agent-skills/issues/167 (issue refreshed with v1.2.11, current free preview, 800,000+ evidence, and passing HOL Plugin Scanner status)
 - Awesome Hermes Agent recommendation issue: https://github.com/0xNyk/awesome-hermes-agent/issues/325 (portable anti-UI-slop skill recommendation for the agentskills.io ecosystem)
+- Awesome Hermes Skills: https://github.com/ZeroPointRepo/awesome-hermes-skills/pull/29 (merged UIZZE anti-ui-slop Skill listing in Creative & Media Generation)
 - Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420
 - Skillmatic Agent Skills PR: https://github.com/skillmatic-ai/awesome-agent-skills/pull/153
 - SkillCreator Agent Skills PR: https://github.com/skillcreatorai/Awesome-Agent-Skills/pull/10


### PR DESCRIPTION
## Summary

- document the current authenticated Glama Add Server route for the canonical repository
- record that the legacy scored server must not be restored
- record the current GitHub Marketplace API limitation and release-form requirement

## Verification

- `git diff --check`
- verified `https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md` serves `version: 1.2.11`
- verified official MCP Registry has canonical `io.github.uizze/uizze` v1.2.11
- verified unauthenticated Glama submission redirects to sign-up rather than accepting an anonymous submission