### PR TITLE
docs: record Claude plugin registry intake

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -49,6 +49,7 @@ Update existing entries first:
 
 - Tons of Skills: https://github.com/uizze/uizze/issues/38 (catalogue validator intake; the public anti-ui-slop Skill now has the required Overview, Prerequisites, Output, Error Handling, and Resources sections, and the live domain-backed copy is verified byte-for-byte against this repository)
 - iFlytek SkillHub: https://github.com/iflytek/skillhub/issues/719 (4,872-star self-hosted Agent Skill registry; starter-collection proposal uses the canonical MIT Skill source and preserves UIZZE's public version/license metadata)
+- Claude Plugins registry: https://github.com/Kamalnrf/claude-plugins/issues/124 (532-star registry with 63,000+ indexed Agent Skills; direct indexing request for the canonical anti-ui-slop Skill after the public index returned no UIZZE match)
 - Glama connector: https://glama.ai/mcp/connectors/io.github.uizze/uizze (canonical hosted record is now verified, has a healthy `glama.json`, points to `https://uizze.com/mcp/preview`, and reports 4.3/5 across one tool; the separate server record at https://glama.ai/mcp/servers/uizze/uizze-mcp still points to retired `uizze/uizze-mcp` and has no score)
 - Glama source-server submission: https://glama.ai/mcp/servers (use **Add Server** → **Server** and submit `https://github.com/uizze/uizze`; the current `/api/mcp/servers/submit` endpoint redirects unauthenticated visitors to sign-up, so the canonical source-server listing and score remain externally gated; do not restore the retired repository)
 - PulseMCP: https://www.pulsemcp.com/servers/uizze


### PR DESCRIPTION
## Summary
- record the direct claude-plugins.dev indexing request in the canonical distribution queue
- preserve the canonical Skill source, version, license, and production verification language

## Verification
- `git diff --check`
- public registry scan returned no existing UIZZE match before submission