### PR TITLE
docs: record Awesome Copilot merge

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -149,7 +149,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18048196
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18048258
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest
 - Anthropic Skills partner listing PR: https://github.com/anthropics/skills/pull/1595 (link-only UIZZE entry for the official Agent Skills repository; maintainer review pending)
 - Claude Code Frontend Design Toolkit PR: https://github.com/wilwaldon/Claude-Code-Frontend-Design-Toolkit/pull/5 (README source repaired to the canonical `uizze/uizze` repository; checks are clean)
@@ -264,7 +264,7 @@ Already listed:
 
 - GitHub MCP Registry: https://github.com/mcp/uizze/uizze (official registry is active at `io.github.uizze/uizze`, latest `v1.2.11`, with the canonical repository URL; older retired-repository records are deprecated)
 - GitHub Awesome Copilot skill: https://github.com/github/awesome-copilot/blob/main/skills/anti-ui-slop/SKILL.md
-- GitHub Awesome Copilot follow-up PR: https://github.com/github/awesome-copilot/pull/2685 (documents the separate anonymous `check_ui_slop` preview; all automated checks pass, maintainer review pending)
+- GitHub Awesome Copilot follow-up PR: https://github.com/github/awesome-copilot/pull/2685 (merged; GitHub's official collection now documents the separate anonymous `check_ui_slop` preview)
 - GitHub Awesome Copilot external plugin intake: https://github.com/github/awesome-copilot/issues/2690 (immutable commit `0d7ab5d`; metadata, Agent Plugins v1 install smoke, `vally lint`, version, and SHA checks pass; `ready-for-review`)
 - Awesome Copilot Agents PR: https://github.com/Code-and-Sorts/awesome-copilot-agents/pull/81 (links the maintained UIZZE anti-ui-slop skill in the Development Agent Skills list)
 - skills.sh: https://www.skills.sh/site/uizze.com/anti-ui-slop

--- a/README.md
+++ b/README.md
@@ -122,5 +122,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [Official MCP Registry record](https://github.com/mcp/uizze/uizze)
 - [GitHub Copilot anti-ui-slop Skill](https://github.com/github/awesome-copilot/tree/main/skills/anti-ui-slop)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18048196)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18048258)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary
- point the public distribution links at the newest Copilot discovery update
- record that Awesome Copilot PR #2685 merged
- keep the external plugin intake status linked from the same map

## Verification
- `git diff --check`
