### PR TITLE
docs: record release notes refresh

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -153,8 +153,8 @@ Keep these surfaces aligned with the canonical copy above:
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18048561
-- Latest distribution release: https://github.com/uizze/uizze/releases/latest
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18048586
+- Latest distribution release: https://github.com/uizze/uizze/releases/latest (v1.2.11 notes refreshed with the live skills.sh install route and current distribution pointer)
 - Anthropic Skills partner listing PR: https://github.com/anthropics/skills/pull/1595 (link-only UIZZE entry for the official Agent Skills repository; maintainer review pending)
 - Claude Code Frontend Design Toolkit PR: https://github.com/wilwaldon/Claude-Code-Frontend-Design-Toolkit/pull/5 (README source repaired to the canonical `uizze/uizze` repository; checks are clean)
 - Awesome Vibe Coding documentation PR: https://github.com/filipecalegario/awesome-vibe-coding/pull/257 (visible entry now leads with the free Skill and deterministic preview, then distinguishes full UIZZE and its 800,000+ real web and iOS screens)

--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [GitHub Copilot anti-ui-slop Skill](https://github.com/github/awesome-copilot/tree/main/skills/anti-ui-slop)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reported 335.6K installs on 2026-08-17)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18048561)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18048586)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary

- document the published v1.2.11 release-note refresh
- point the canonical map and README at the current distribution discussion

## Validation

- `git diff --check`
- `gh release view v1.2.11` confirms the updated public paths
- no tag, version, or release identity changed