### PR TITLE
fix: align legacy Copilot plugin manifest

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "business@uizze.com"
   },
   "metadata": {
-    "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+    "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate to stop generic UI before it ships.",
     "version": "1.2.11"
   },
   "plugins": [
     {
       "name": "uizze-ui-slop",
       "source": "./",
-      "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+      "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate to stop generic UI before it ships.",
       "version": "1.2.11"
     }
   ]

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,10 +1,10 @@
 {
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "uizze-ui-slop",
-  "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+  "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate to stop generic UI before it ships.",
   "version": "1.2.11",
   "author": {
     "name": "UIZZE",
-    "email": "business@uizze.com",
     "url": "https://uizze.com"
   },
   "homepage": "https://uizze.com",
@@ -15,9 +15,14 @@
     "design",
     "frontend",
     "anti-slop",
-    "agent-skill"
+    "agent-skill",
+    "github-copilot"
   ],
-  "category": "Developer Tools",
-  "skills": "./skills/",
-  "mcpServers": ".mcp.json"
+  "extensions": {
+    "com.github.awesome-copilot": {
+      "skills": [
+        "../../skills/anti-ui-slop/"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- align `.github/plugin/plugin.json` with Agent Plugins v1 schema
- remove unsupported `category`, `skills`, and `mcpServers` fields from the duplicate legacy manifest
- point the Copilot extension at the canonical root Skill with a valid relative reference
- synchronize the legacy marketplace descriptions with the canonical anti-UI-slop copy

## Validation

- `jq empty` passes for all plugin manifests
- the legacy relative Skill reference resolves to `skills/anti-ui-slop/SKILL.md`
- `git diff --check`
- no credentials or private assets added