### PR TITLE
docs: record Vibe Coding resource refresh

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -312,7 +312,7 @@ Already listed:
 - Developer Resources: https://github.com/marcelscruz/dev-resources/pull/1170 (merged UIZZE entry in a 1,327-star collaborative developer-resources list)
 - ToolSDK MCP Registry: https://github.com/toolsdk-ai/toolsdk-mcp-registry/pull/398 (merged structured MCP registry entry; follow-up PR #458 repairs the lingering retired-repository URL and aligns the free Skill/no-account preview versus full hosted MCP copy; validation and Biome checks pass)
 - Wundercorp Awesome MCP: https://github.com/wundercorp/awesome-mcp/pull/47 (follow-up to merged PR #24; repairs the existing design-directory entry to use canonical `uizze/uizze` and the current free/full scope; catalog validation passes)
-- Awesome Vibe Coding Resources: https://github.com/acvnace/awesome-vibe-coding-resources/pull/45 (merged UIZZE anti-UI-slop workflow entry in the 266-star resource list)
+- Awesome Vibe Coding Resources: https://github.com/acvnace/awesome-vibe-coding-resources/pull/45 (merged UIZZE anti-UI-slop workflow entry in the 267-star resource list); maintenance refresh: https://github.com/acvnace/awesome-vibe-coding-resources/pull/69 (updates the existing line with the free MIT Skill, design-contract/finish-gate workflow, and accurate full 800,000+ scope)
 - Awesome Webdesign Tools: https://github.com/nafasebra/awesome-webdesign-tools/pull/59 (merged UIZZE design-tool entry in the 159-star website/CSS tools list)
 - Awesome Agent Skills: https://github.com/JayLZhou/Awesome-Agent-Skills/pull/22 (merged UIZZE ecosystem resource in the 136-star Agent Skills list)
 - Awesome Inspiration: https://github.com/shsfwork/awesome-inspiration/pull/13 (merged UIZZE entry in the 99-star design and developer inspiration list)


### PR DESCRIPTION
## Summary
- record the maintenance refresh for the existing UIZZE placement in Awesome Vibe Coding Resources
- preserve the directory’s 267-star discovery route while tracking the current free MIT Skill and full 800,000+ scope

## Verification
- `git diff --check`
- upstream PR #69 is clean and mergeable