### PR TITLE
docs: point to latest distribution log

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [GitHub Copilot anti-ui-slop Skill](https://github.com/github/awesome-copilot/tree/main/skills/anti-ui-slop)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18058549)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18058606)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary
- repoint the root README’s latest distribution link to the newly published skills.sh metric update

## Verification
- `git diff --check`
- discussion comment `18058606` verified live