### PR TITLE
docs: track Agent Skill Index distribution route

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -191,7 +191,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Tech Leads Club Agent Skills intake issue: https://github.com/tech-leads-club/agent-skills/issues/167 (issue refreshed with v1.2.11, current free preview, 800,000+ evidence, and passing HOL Plugin Scanner status)
 - Awesome Hermes Agent recommendation issue: https://github.com/0xNyk/awesome-hermes-agent/issues/325 (portable anti-UI-slop skill recommendation for the agentskills.io ecosystem)
 - Awesome Hermes Skills: https://github.com/ZeroPointRepo/awesome-hermes-skills/pull/29 (merged UIZZE anti-ui-slop Skill listing in Creative & Media Generation); maintenance refresh: https://github.com/ZeroPointRepo/awesome-hermes-skills/pull/50 (419-star Hermes ecosystem directory; updates the existing copy with the MIT Skill, no-account preview, and accurate full 800,000+ scope; format check passes)
-- Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420 (existing UIZZE listing; current verification comment confirms the canonical Skill, free install path, v1.2.11 metadata, and 800,000+ evidence)
+- Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420 (6,110-star Agent Skill directory; the existing UIZZE row now names the free MIT Skill, no-account preview checks, and the optional full workflow across 800,000+ real web and iOS screens; refreshed in commit `0eed872`, maintainer review pending)
 - Skillmatic Agent Skills PR: https://github.com/skillmatic-ai/awesome-agent-skills/pull/153
 - SkillCreator Agent Skills PR: https://github.com/skillcreatorai/Awesome-Agent-Skills/pull/10
 - Claude Code Toolkit PR: https://github.com/rohitg00/awesome-claude-code-toolkit/pull/730


### PR DESCRIPTION
## Summary

- Track the existing UIZZE submission in the 6,110-star Agent Skill Index.
- Record the refreshed free-first copy and current maintainer-review state.
- Keep the canonical distribution map aligned with the live PR.

External route: https://github.com/heilcheng/awesome-agent-skills/pull/420

## Verification

- Documentation-only change.
- `DISTRIBUTION.md` points to the canonical `uizze/uizze` source and current UIZZE wording.
- External listing update is pushed in `samuelbushi/awesome-agent-skills@0eed872`.