### PR TITLE
docs: track Cursor skills directory PR

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -123,6 +123,7 @@ Submit the canonical repository next:
 - GetBindu Awesome Claude Skills: https://github.com/GetBindu/awesome-claude-code-and-skills (PR #156 adds UIZZE to Core Development Skills)
 - BehiSecc Awesome Claude Skills: https://github.com/BehiSecc/awesome-claude-skills (PR #579 adds UIZZE to Development & Code Tools)
 - Official Cursor plugins: https://github.com/cursor/plugins (PR #217 adds the UIZZE Cursor plugin; its branch now includes Cursor `main` through conflict-resolution commit `8aef74e`, the marketplace JSON parses, and Cursor Bugbot passed; maintainer review remains pending)
+- Awesome Cursor Skills: https://github.com/spencerpauly/awesome-cursor-skills (697-star Cursor-specific directory; PR #49 adds the free-first anti-ui-slop Skill under Frontend & UI and is clean and mergeable)
 - Docker MCP Registry: https://github.com/docker/mcp-registry (PR #4473 now points at the canonical `uizze/uizze` repository and uses the current 800,000+ real web and iOS screens copy; Docker maintainer review is pending)
 - Cline marketplace: https://github.com/cline/marketplace (PR #17 adds the free anti-ui-slop Skill; commit `8116320` now separates its free workflow from the optional full UIZZE MCP and repository validation passes with 203 entries; PR #18 adds the no-account preview MCP; both remain open for maintainer review)
 - Cline plugins: https://github.com/cline/plugins (PR #224 adds the portable anti-ui-slop plugin; maintainer review is pending)
@@ -244,6 +245,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Anthony Fu Skills PR: https://github.com/antfu/skills/pull/36 (canonical UIZZE anti-ui-slop Skill synced through the repository’s vendor workflow; lint and sync parity passed; maintainer review pending)
 - Alirezarezvani Claude Skills proposal: https://github.com/alirezarezvani/claude-skills/issues/962 (new anti-ui-slop quality-gate proposal; maintainer review pending)
 - Official Cursor plugins PR: https://github.com/cursor/plugins/pull/217 (manifest synchronized to v1.2.11 and current 800,000+ real web and iOS screens copy; conflict-resolution commit `8aef74e` preserves the upstream Juicebox update, marketplace JSON parses, and Cursor Bugbot passed; Cursor review is pending)
+- Awesome Cursor Skills PR: https://github.com/spencerpauly/awesome-cursor-skills/pull/49 (697-star Cursor directory; README-only entry with the canonical install, no-account preview, and separated optional 800,000+ workflow; clean and mergeable)
 - Docker MCP Registry PR: https://github.com/docker/mcp-registry/pull/4473 (canonical source and current public copy corrected in commit `ceaad7ba`; Docker review is pending)
 - Cline marketplace Skill PR: https://github.com/cline/marketplace/pull/17 (scope clarification commit `8116320`; free Skill and optional full MCP are now described separately; validation passes with 203 entries; review pending)
 - Cline marketplace MCP PR: https://github.com/cline/marketplace/pull/18


### PR DESCRIPTION
## Summary

Track the new UIZZE submission to `spencerpauly/awesome-cursor-skills`.

- Directory: 697-star Cursor-specific skills list
- PR: https://github.com/spencerpauly/awesome-cursor-skills/pull/49
- State: clean and mergeable
- Copy: free MIT Skill first, canonical install, no-account preview, optional 800,000+ workflow
