### PR TITLE
docs: refresh latest distribution pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [Agent Skill Index listing](https://github.com/heilcheng/awesome-agent-skills/pull/420) (6,110-star directory; maintainer review pending)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18059482)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18059783)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary

- Points the canonical README at the latest Distribution Discussion update.
- Keeps the primary GitHub entry point aligned with the release notes and organization profile.

## Verification

- `git diff --check`
- Latest discussion: https://github.com/uizze/uizze/discussions/44#discussioncomment-18059783
