### PR TITLE
fix(external-sync): use parser-safe public CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://
 
 This is the single public home for UIZZE: the `anti-ui-slop` skill, agent plugins, MCP setup, GitHub Action, Kiro Power, integrations, examples, and benchmarks.
 
-<p><a href="https://uizze.com"><strong>STOP UI SLOP →</strong></a></p>
+[**STOP UI SLOP →**](https://uizze.com)
 
 ## Install
 


### PR DESCRIPTION
## Summary

- replace the HTML CTA in the public README with a standard Markdown link
- keep the public UIZZE CTA identical in intent while making downstream directory link scanners parse it correctly

## Why this matters

The Tons of Skills mirror validator correctly allows `uizze.com`, but its URL extraction treats the HTML closing markup after the URL as part of the link. Markdown is clearer on GitHub and avoids that false-positive when the canonical README is mirrored.

## Verification

- `git diff --check`
