### PR TITLE
docs: point to latest distribution update

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [Agent Skill Index listing](https://github.com/heilcheng/awesome-agent-skills/pull/420) (6,110-star directory; maintainer review pending)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18059783)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18060242)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
Points the repository's public Distribution section to the latest indexed GitHub Discussion handoff (#18060242), which includes the current high-signal listing queue and the free/full wording rule.