### PR TITLE
docs: record accepted developer-resources profile route

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -176,7 +176,7 @@ Submit the canonical repository next:
 
 Keep these surfaces aligned with the canonical copy above:
 
-- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PR #25 merged; profile now surfaces high-signal Codex, frontend system-design, and MCP directory routes)
+- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25 and #26 merged; profile now surfaces accepted Developer Resources plus high-signal Codex, frontend system-design, and MCP directory routes)
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
 - Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18059482


### PR DESCRIPTION
## Summary

Update the canonical distribution map to reflect the accepted Developer Resources listing and latest organization-profile refresh.

- Accepted listing: https://github.com/marcelscruz/dev-resources/pull/1170
- Organization profile PR: https://github.com/uizze/.github/pull/26

Documentation-only distribution update, based on current main.