### PR TITLE
docs: surface additional high-reach GitHub routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - [GreatFrontEnd Front-End System Design submission](https://github.com/greatfrontend/awesome-front-end-system-design/pull/9) (8,400+ star directory; maintainer review pending)
 - [Awesome MCP Servers submission](https://github.com/punkpeye/awesome-mcp-servers/pull/10946) (92,000+ star directory; Glama scored-server requirement remains external)
 - [Agent Skill Index listing](https://github.com/heilcheng/awesome-agent-skills/pull/420) (6,110-star directory; maintainer review pending)
+- Additional high-reach routes under review: [Anthropic Agent Skills](https://github.com/anthropics/skills/pull/1595) (170,000+ stars), [Claude Code Best Practice](https://github.com/shanraisshan/claude-code-best-practice/pull/187) (64,000+ stars), [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code/issues/2548) (52,000+ stars), [Awesome Actions](https://github.com/sdras/awesome-actions/pull/899) (28,000+ stars), and [Awesome Design](https://github.com/gztchan/awesome-design/pull/229) (17,000+ stars)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
 - [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18060242)


### PR DESCRIPTION
## Summary

- surface five additional high-reach routes directly from the canonical README
- link Anthropic Agent Skills, Claude Code Best Practice, Awesome Claude Code, Awesome Actions, and Awesome Design to their current intake pages
- use live GitHub star-count snapshots from 2026-08-18

## Verification

- git diff --check
- all five referenced routes are open and the pull requests are mergeable where applicable
- matching shortlist is live in uizze/.github#29