### PR TITLE
docs: align distribution pointers with latest shortlist

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -176,10 +176,10 @@ Submit the canonical repository next:
 
 Keep these surfaces aligned with the canonical copy above:
 
-- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25–#28 merged; profile now surfaces accepted Agentic Awesome Skills, Developer Resources, Agency Agents, and Build with Claude plus high-signal Codex, frontend system-design, and MCP directory routes)
+- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25–#29 merged; profile now surfaces accepted Agentic Awesome Skills, Developer Resources, Agency Agents, and Build with Claude plus the five-route high-reach shortlist and high-signal Codex, frontend system-design, and MCP directory routes)
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18060242
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18060854
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest (v1.2.11 notes refreshed with the live skills.sh install route and current distribution pointer)
 - Anthropic Skills partner listing PR: https://github.com/anthropics/skills/pull/1595 (link-only UIZZE entry for the official Agent Skills repository; maintainer review pending)
 - Claude Code Frontend Design Toolkit PR: https://github.com/wilwaldon/Claude-Code-Frontend-Design-Toolkit/pull/5 (README source repaired to the canonical `uizze/uizze` repository; checks are clean)

--- a/README.md
+++ b/README.md
@@ -132,5 +132,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - Additional high-reach routes under review: [Anthropic Agent Skills](https://github.com/anthropics/skills/pull/1595) (170,000+ stars), [Claude Code Best Practice](https://github.com/shanraisshan/claude-code-best-practice/pull/187) (64,000+ stars), [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code/issues/2548) (52,000+ stars), [Awesome Actions](https://github.com/sdras/awesome-actions/pull/899) (28,000+ stars), and [Awesome Design](https://github.com/gztchan/awesome-design/pull/229) (17,000+ stars)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18060242)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18060854)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
## Summary

- point the canonical README and distribution map at the latest discussion update
- record merged organization profile PR #29 and its five-route high-reach shortlist

## Verification

- git diff --check
- discussion comment 18060854 is live
- profile PR #29 and README shortlist PR #280 are merged