### PR TITLE
docs: record latest org profile route

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -177,7 +177,7 @@ Submit the canonical repository next:
 
 Keep these surfaces aligned with the canonical copy above:
 
-- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25–#29 merged; profile now surfaces accepted Agentic Awesome Skills, Developer Resources, Agency Agents, and Build with Claude plus the five-route high-reach shortlist and high-signal Codex, frontend system-design, and MCP directory routes)
+- Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25–#30 merged; profile now surfaces accepted Agentic Awesome Skills, Developer Resources, Agency Agents, and Build with Claude plus the five-route high-reach shortlist and high-signal Codex, frontend system-design, and MCP directory routes)
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
 - Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18061088


### PR DESCRIPTION
Synchronize the distribution map with merged uizze/.github#30. The organization profile now includes the Awesome DevOps MCP Servers route and current discussion evidence; this keeps the canonical map's profile range accurate.