### PR TITLE
docs: align Hello-Agents discussion pointer

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -183,7 +183,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Organization profile: https://github.com/uizze/.github/blob/main/profile/README.md (PRs #25–#31 merged; profile now surfaces accepted Agentic Awesome Skills, Developer Resources, Agency Agents, and Build with Claude plus the five-route high-reach shortlist and high-signal Codex, frontend system-design, MCP, and Agentic Patterns routes)
 - Start-here discussion: https://github.com/uizze/uizze/discussions/15 (high-traffic entry point refreshed with canonical links, free preview, Action, DESIGN.md, and Registry paths)
 - Launch discussion: https://github.com/uizze/uizze/discussions/44
-- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18061510
+- Latest distribution update: https://github.com/uizze/uizze/discussions/44#discussioncomment-18061709
 - Latest distribution release: https://github.com/uizze/uizze/releases/latest (v1.2.11 notes refreshed with the live skills.sh install route and current distribution pointer)
 - Domain Skill Install parity: https://github.com/uizze/uizze/actions/runs/32106467971 (manual verification passed after app PR #188 and the parity-only Cloudflare deployment; the live installer and canonical `skills/anti-ui-slop/SKILL.md` are byte-identical at SHA-256 `f6ebda2901effc3132c35b5cfde04e4cfab2a1cc89f7ee0d136b490551d8d764`)
 - Anthropic Skills partner listing PR: https://github.com/anthropics/skills/pull/1595 (link-only UIZZE entry for the official Agent Skills repository; maintainer review pending)

--- a/README.md
+++ b/README.md
@@ -136,5 +136,5 @@ Use [DISTRIBUTION.md](DISTRIBUTION.md) for canonical public copy, install langua
 - Additional high-reach routes under review: [Anthropic Agent Skills](https://github.com/anthropics/skills/pull/1595) (170,000+ stars), [Claude Code Best Practice](https://github.com/shanraisshan/claude-code-best-practice/pull/187) (64,000+ stars), [Awesome Claude Code](https://github.com/hesreallyhim/awesome-claude-code/issues/2548) (52,000+ stars), [Awesome Actions](https://github.com/sdras/awesome-actions/pull/899) (28,000+ stars), and [Awesome Design](https://github.com/gztchan/awesome-design/pull/229) (17,000+ stars)
 - [UIZZE on skills.sh](https://www.skills.sh/site/uizze.com/anti-ui-slop) (free install listing; the page reports 348.5K installs on 2026-08-18, a third-party directory metric rather than a UIZZE product-usage claim)
 - [UIZZE organization profile](https://github.com/uizze)
-- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18061510)
+- [Latest distribution update](https://github.com/uizze/uizze/discussions/44#discussioncomment-18061709)
 - [Full distribution map](DISTRIBUTION.md)


### PR DESCRIPTION
Align the canonical README and DISTRIBUTION.md latest-update links with the newest Hello-Agents distribution ledger comment.

- Replace discussion comment 18061510 with 18061709
- This matches v1.2.11 release notes and the merged organization profile update

Docs-only pointer correction.