### PR TITLE
docs: standardize anti-ui-slop distribution copy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "business@uizze.com"
   },
   "metadata": {
-    "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+    "description": "Stop AI coding agents from shipping generic UI with a free anti-ui-slop Skill, a UI Slop Gate, and optional UIZZE research across 800,000+ real web and iOS screens.",
     "version": "1.2.11"
   },
   "plugins": [
     {
       "name": "uizze",
       "source": "./",
-      "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+      "description": "Stop AI coding agents from shipping generic UI with a free anti-ui-slop Skill, a UI Slop Gate, and optional UIZZE research across 800,000+ real web and iOS screens.",
       "version": "1.2.11",
       "author": {
         "name": "UIZZE",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "uizze",
   "displayName": "UIZZE",
   "version": "1.2.11",
-  "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+  "description": "Stop AI coding agents from shipping generic UI with a free anti-ui-slop Skill, a UI Slop Gate, and optional UIZZE research across 800,000+ real web and iOS screens.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uizze",
   "version": "1.2.11",
-  "description": "If your UI screams AI, your app is dead. Stop UI slop with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+  "description": "Stop AI coding agents from shipping generic UI with a free anti-ui-slop Skill, a UI Slop Gate, and optional UIZZE research across 800,000+ real web and iOS screens.",
   "author": {
     "name": "UIZZE",
     "email": "business@uizze.com",
@@ -27,7 +27,7 @@
   "interface": {
     "displayName": "UIZZE",
     "shortDescription": "Stop UI slop before it ships",
-    "longDescription": "If your UI screams AI, your app is dead. Build distinctive UI with 800,000+ real web and iOS screens, a product-specific design contract, and a hard finish gate.",
+    "longDescription": "Stop AI coding agents from shipping generic UI. Start with the free anti-ui-slop Skill and UI Slop Gate; add optional UIZZE research across 800,000+ real web and iOS screens when it materially improves the work.",
     "composerIcon": "./integrations/mcp/assets/uizze-logo-400x400.png",
     "logo": "./integrations/mcp/assets/uizze-logo-400x400.png",
     "developerName": "UIZZE",
@@ -39,7 +39,7 @@
     "privacyPolicyURL": "https://uizze.com/privacy",
     "termsOfServiceURL": "https://uizze.com/terms",
     "defaultPrompt": [
-      "Use UIZZE to kill the generic defaults and plan this interface from real product evidence.",
+      "Use UIZZE to plan this interface from real product evidence, then run the finish gate before shipping.",
       "Run the UIZZE finish gate and fix every blocking issue before shipping.",
       "Use UIZZE to make this interface unmistakably belong to this product."
     ],

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "business@uizze.com"
   },
   "metadata": {
-    "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate to stop generic UI before it ships.",
+    "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate for generic UI risks.",
     "version": "1.2.11"
   },
   "plugins": [
     {
       "name": "uizze-ui-slop",
       "source": "./",
-      "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate to stop generic UI before it ships.",
+      "description": "A UI quality workflow for coding agents that uses 800,000+ real web and iOS screens, a product-specific design contract, required interface states, and a hard finish gate for generic UI risks.",
       "version": "1.2.11"
     }
   ]

--- a/.github/workflows/domain-skill-install.yml
+++ b/.github/workflows/domain-skill-install.yml
@@ -49,7 +49,7 @@ jobs:
           test -s "$skill"
           grep -qx 'name: anti-ui-slop' "$skill"
           grep -qx '# Stop Making UI Slop' "$skill"
-          grep -Fqx '> ***If your UI screams AI, your app is dead.***' "$skill"
+          grep -Fqx '> **Stop AI coding agents from shipping generic UI.**' "$skill"
           grep -Fq 'anti-ui-slop-skill-banner.png' "$skill"
           grep -Fq 'https://uizze.com' "$skill"
           if grep -Fq 'github.com' "$skill"; then

--- a/.github/workflows/uizze-ui-review.yml
+++ b/.github/workflows/uizze-ui-review.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Stop UI slop

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -209,7 +209,7 @@ Keep these surfaces aligned with the canonical copy above:
 - Agent Skill Index PR: https://github.com/heilcheng/awesome-agent-skills/pull/420 (6,110-star Agent Skill directory; the existing UIZZE row now names the free MIT Skill, no-account preview checks, and the optional full workflow across 800,000+ real web and iOS screens; refreshed in commit `0eed872`, maintainer review pending)
 - Skillmatic Agent Skills PR: https://github.com/skillmatic-ai/awesome-agent-skills/pull/154 (supersedes duplicate PR #153)
 - SkillCreator Agent Skills PR: https://github.com/skillcreatorai/Awesome-Agent-Skills/pull/10
-- Claude Code Toolkit PR: https://github.com/rohitg00/awesome-claude-code-toolkit/pull/734 (2,524-star Claude Code toolkit; adds the free MIT anti-ui-slop Skill to Community Skills with the canonical install command and a separated optional 800,000+ workflow; clean and mergeable)
+- Claude Code Toolkit PR: https://github.com/rohitg00/awesome-claude-code-toolkit/pull/734 (2,525-star Claude Code toolkit; adds the free MIT anti-ui-slop Skill to Community Skills with the canonical install command and a separated optional 800,000+ workflow; CodeRabbit review is green after the install/count copy repair recorded at https://github.com/rohitg00/awesome-claude-code-toolkit/pull/734#issuecomment-5326040413)
 - Awesome Cursor Rules PR: https://github.com/PatrickJS/awesome-cursorrules/pull/353
 - Awesome Claude Skills PR: https://github.com/ComposioHQ/awesome-claude-skills/pull/1648 (all validation and Socket checks pass; the entry leads with the free MIT Skill and separates the optional 800,000+ workflow)
 - Awesome Codex Skills PR: https://github.com/composio-community/awesome-codex-skills/pull/236

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with a free anti-ui-slop Skill and UI Slop Gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/examples/agent-workflows.md
+++ b/examples/agent-workflows.md
@@ -26,7 +26,7 @@ Install the repository as a Claude Code plugin:
 Then run:
 
 ```text
-Use uizze:anti-ui-slop to kill the generic defaults and finish this interface in the product's existing visual language.
+Use uizze:anti-ui-slop to identify generic UI decisions and finish this interface in the product's existing visual language.
 ```
 
 ## Cursor

--- a/integrations/benchmark/README.md
+++ b/integrations/benchmark/README.md
@@ -1,8 +1,8 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with the free, reproducible UI finish gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/integrations/benchmark/site/index.html
+++ b/integrations/benchmark/site/index.html
@@ -4,14 +4,14 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A free, reproducible UI finish gate for coding agents. Catch generic UI before it ships." />
-    <meta property="og:title" content="If your UI screams AI, your app is dead." />
+    <meta property="og:title" content="Stop AI coding agents from shipping generic UI." />
     <meta property="og:description" content="A free, reproducible UI finish gate for coding agents. Catch generic UI before it ships." />
     <meta property="og:type" content="website" />
     <link rel="canonical" href="https://benchmark.uizze.com/" />
     <meta property="og:url" content="https://benchmark.uizze.com/" />
     <meta property="og:image" content="https://uizze.com/landing/anti-ui-slop-skill-banner.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="If your UI screams AI, your app is dead." />
+    <meta name="twitter:title" content="Stop AI coding agents from shipping generic UI." />
     <meta name="twitter:description" content="A free, reproducible UI finish gate for coding agents. Catch generic UI before it ships." />
     <meta name="twitter:image" content="https://uizze.com/landing/anti-ui-slop-skill-banner.png" />
     <title>STOP UI SLOP — free UIZZE finish gate</title>

--- a/integrations/codex-finish-gate/README.md
+++ b/integrations/codex-finish-gate/README.md
@@ -1,8 +1,8 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with the free Codex finish gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -1,8 +1,8 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com/github-action).
+Build product-specific UI with the free UI Slop Gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com/github-action).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/integrations/github-action/action.yml
+++ b/integrations/github-action/action.yml
@@ -1,5 +1,5 @@
 name: UIZZE UI Slop Gate
-description: If your UI screams AI, your app is dead. Catch UI slop in every pull request before it ships.
+description: Free GitHub Action that checks every pull request for generic UI, missing states, inert controls, and token drift.
 author: UIZZE
 
 branding:

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,4 +1,4 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # UIZZE UI Slop Finish Gate for Kiro
 

--- a/integrations/mcp/skills/uizze-ui-research/SKILL.md
+++ b/integrations/mcp/skills/uizze-ui-research/SKILL.md
@@ -3,15 +3,15 @@ name: uizze-ui-research
 description: Stop UI slop before it ships. Use 800,000+ real web and iOS screens to make Codex, Claude Code, Cursor, Copilot, and other coding agents build product-specific interfaces instead of disposable card-grid defaults. Apply a design contract and a hard finish gate when designing, implementing, restyling, or reviewing product UI.
 ---
 
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 
-Kill the interchangeable card grid before it reaches users. Turn real interface evidence into a concrete design contract, build in the product's own visual language, then run a hard finish gate before shipping.
+Use real interface evidence instead of a default card grid. Turn that evidence into a concrete design contract, build in the product's own visual language, then run a hard finish gate before shipping.
 
 Use this skill for free. Do not require a paid UIZZE account to apply the catalogue-driven workflow below.
 

--- a/integrations/mcp/skills/uizze-ui-research/agents/openai.yaml
+++ b/integrations/mcp/skills/uizze-ui-research/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "UIZZE — Stop Making UI Slop"
-  short_description: "Stop UI slop before it ships"
-  default_prompt: "Use $uizze-ui-research to kill generic UI, ground this interface in real product evidence, and run a hard finish gate before shipping."
+  short_description: "Catch generic UI before it ships"
+  default_prompt: "Use $uizze-ui-research to identify generic UI decisions, ground this interface in real product evidence, and run a hard finish gate before shipping."

--- a/integrations/nextjs-starter/README.md
+++ b/integrations/nextjs-starter/README.md
@@ -1,8 +1,8 @@
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with the free anti-ui-slop Skill and UI Slop Gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/integrations/storybook/README.md
+++ b/integrations/storybook/README.md
@@ -1,8 +1,8 @@
-> **_If your UI screams AI, your app is dead._**
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with the free Storybook finish gate. Optional full UIZZE adds 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
+++ b/plugins/claude-directory/skills/anti-ui-slop/SKILL.md
@@ -10,11 +10,11 @@ compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; work
 tags: [ui-design, design-system, design-review, frontend, web-ui, ios-ui]
 ---
 
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
+++ b/plugins/openai-directory/uizze/skills/anti-ui-slop/SKILL.md
@@ -10,11 +10,11 @@ compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; work
 tags: [ui-design, design-system, design-review, frontend, web-ui, ios-ui]
 ---
 
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/skills/anti-ui-slop/SKILL.md
+++ b/skills/anti-ui-slop/SKILL.md
@@ -10,11 +10,11 @@ compatibility: Designed for Claude Code, Codex, Cursor, and GitHub Copilot; work
 tags: [ui-design, design-system, design-review, frontend, web-ui, ios-ui]
 ---
 
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Stop Making UI Slop
 
-Build distinctive UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
+Build product-specific UI with 800,000+ real web and iOS screens via [UIZZE](https://uizze.com).
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 

--- a/skills/anti-ui-slop/agents/openai.yaml
+++ b/skills/anti-ui-slop/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "UIZZE — STOP UI SLOP"
-  short_description: "Kill generic UI before it reaches users"
-  default_prompt: "Use $anti-ui-slop to kill generic UI, ground this interface in real product evidence, and run a hard finish gate before shipping."
+  short_description: "Catch generic UI before it ships"
+  default_prompt: "Use $anti-ui-slop to identify generic UI decisions, ground this interface in real product evidence, and run a hard finish gate before shipping."

--- a/skills/ui-slop-score/SKILL.md
+++ b/skills/ui-slop-score/SKILL.md
@@ -4,7 +4,7 @@ description: Score a rendered web or iOS screen for generic UI risk before it sh
 license: MIT
 ---
 
-> ***If your UI screams AI, your app is dead.***
+> **Stop AI coding agents from shipping generic UI.**
 
 # Score UI Slop Before It Ships
 


### PR DESCRIPTION
## Summary\n- standardize the public headline around stopping AI coding agents from shipping generic UI\n- align README, plugin manifests, Marketplace metadata, Action docs, integrations, and benchmark social metadata\n- keep the free anti-ui-slop Skill and UI Slop Gate distinct from optional UIZZE research across 800,000+ real web and iOS screens\n\n## Verification\n- JSON manifest parsing passed\n- Skill mirror parity passed\n- domain installer assertion updated and passed\n- git diff --check passed\n- live app parity commit: https://github.com/uizze/app/commit/bf8f14ee