### PR TITLE
Make GitHub discovery lead to a working first UI task

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -26,8 +26,12 @@ Production is the source of truth. Directory copy must match these endpoints:
 | Surface | URL |
 | --- | --- |
 | GitHub | https://github.com/uizze/uizze |
+| GitHub MCP Registry | https://github.com/mcp/uizze/uizze |
+| GitHub Awesome Copilot | https://github.com/github/awesome-copilot/tree/main/plugins/uizze |
+| Agentic Awesome Skills | https://github.com/sickn33/agentic-awesome-skills/tree/main/skills/anti-ui-slop |
+| Build with Claude | https://github.com/davepoon/buildwithclaude/tree/main/plugins/all-skills/skills/anti-ui-slop |
+| Tons of Skills | https://github.com/jeremylongshore/tons-of-skills-marketplace/tree/main/plugins/design/uizze |
 | Official MCP Registry | https://registry.modelcontextprotocol.io/v0/servers?search=uizze |
-| skills.sh | https://www.skills.sh/site/uizze.com |
 | Glama | https://glama.ai/mcp/connectors/io.github.uizze/uizze |
 | MCP Market | https://mcpmarket.com/server/uizze-1 |
 | MCPServers.org | https://mcpservers.org/servers/uizze-com |
@@ -35,3 +39,5 @@ Production is the source of truth. Directory copy must match these endpoints:
 Do not track star counts, submission queues, failed pitches, or copied listing
 text here. Use the production metadata above whenever a directory needs a
 refresh.
+
+For redistribution and catalog license fields, see [the license map](LICENSING.md).

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,18 @@
+# UIZZE license map
+
+This repository contains material under more than one license. A skill's metadata does not replace the licenses and notices bundled with its files.
+
+| Material | License / notice |
+| --- | --- |
+| Uizze-authored repository code and text, unless a more specific notice applies | [Root MIT license](LICENSE) |
+| `anti-ui-slop` entry-point instructions | MIT, as declared in [SKILL.md](skills/anti-ui-slop/SKILL.md) |
+| Design-stack playbooks bundled with `anti-ui-slop` | [Apache License 2.0](skills/anti-ui-slop/LICENSE); see [MANIFEST.json](skills/anti-ui-slop/MANIFEST.json) and [modifications notice](skills/anti-ui-slop/MODIFICATIONS.md) |
+| `ui-design` skill and bundled design-stack playbooks | [Apache License 2.0](skills/ui-design/LICENSE), as declared in [SKILL.md](skills/ui-design/SKILL.md) |
+| Third-party material identified inside the packages | Retains its original notices, including the [package NOTICE](skills/anti-ui-slop/NOTICE) |
+| GitHub Action | [MIT](integrations/github-action/LICENSE) |
+
+The `anti-ui-slop` package combines an MIT entry point with Apache-2.0 design-stack material. Describing the entire bundle as exclusively MIT omits that distinction. Plugin copies preserve the same package files and notices.
+
+For a catalog entry, **“free UI design workflow”** or **“free anti-ui-slop skill”** describes the offering without flattening its licenses. If the catalog requires licensing detail, link to this map and retain the original package licenses, attribution, and modification notices when redistributing it.
+
+Access to UIZZE's hosted service and reference library follows the [service terms](https://uizze.com/terms). The code and skill licenses do not grant rights to reuse another product's branding or reference-screen assets.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,106 @@
-> **Stop AI coding agents from shipping generic UI.**
+# UIZZE · Better UI for coding agents
 
-# Stop Making UI Slop
+**Build interfaces that look like your product.** Give Codex, Claude Code, Cursor, and GitHub Copilot a focused UI workflow, with optional references from **800,000+ real web and iOS screens**.
 
-Build product-specific UI with free skills and, when useful, focused
-references from [UIZZE](https://uizze.com).
-
-![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
+[![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_banner)
 
 [![CI](https://github.com/uizze/uizze/actions/workflows/ci.yml/badge.svg)](https://github.com/uizze/uizze/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-black.svg)](LICENSE)
+[![Licenses: MIT and Apache-2.0](https://img.shields.io/badge/Licenses-MIT_%2F_Apache--2.0-black.svg)](LICENSING.md)
+[![GitHub MCP Registry](https://img.shields.io/badge/GitHub-MCP_Registry-181717?logo=github)](https://github.com/mcp/uizze/uizze)
 
-## Install a skill
+[**Explore UIZZE →**](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_product) · [Try a workflow](examples/agent-workflows.md) · [Connect MCP](integrations/mcp) · [Add the PR check](integrations/github-action)
 
-Use `ui-design` as the broad design and implementation workflow:
+## Start with your next screen
+
+Install the free UI design skill:
 
 ```bash
 npx skills add https://uizze.com --skill ui-design
 ```
 
-Use `anti-ui-slop` when the task is specifically about preventing or reviewing
-generic UI:
+Then give your agent a real task:
+
+```text
+Use ui-design to improve our billing settings page. Make the current plan,
+payment method, and invoices easy to scan. Reuse our components and design
+tokens. Include loading, empty, error, and permission states. Inspect the
+result at desktop and mobile sizes and fix what breaks.
+```
+
+The skills work without an account or MCP connection. Start in an existing project: your brief, components, and design system guide the work.
+
+| Your task | Free skill | What to ask for |
+| --- | --- | --- |
+| Build or redesign an interface | [`ui-design`](skills/ui-design) | A clear hierarchy, working interactions, and the states your users need |
+| Fix a generic first draft | [`anti-ui-slop`](skills/anti-ui-slop) | Product-specific content, deliberate layouts, and a finish review |
+| Investigate a UI decision | [`ui-radar`](skills/ui-radar) | A focused reference workflow; connect the paid MCP for live retrieval |
+
+For a focused review, install `anti-ui-slop` instead:
 
 ```bash
 npx skills add https://uizze.com --skill anti-ui-slop
 ```
 
-The skills work without an account, token, script, or MCP connection. The
-domain packages are canonical; this repository mirrors them for GitHub-native
-installers.
+Prefer installing from GitHub? Use `npx skills add uizze/uizze --skill ui-design`. The domain packages remain canonical; this repository mirrors all three skills.
 
-## Connect the paid MCP
+## Bring real product references into the conversation
 
-Create an agent token in [UIZZE](https://uizze.com), keep it out of source
-control, and connect the authenticated endpoint:
+Use UIZZE when the agent needs to see how real products handle a specific design problem: a dense settings page, a permission flow, an invoice table, or an iOS onboarding screen.
 
-```bash
-export UIZZE_AGENT_TOKEN="uizze_at_your_token"
-codex mcp add uizze --url https://uizze.com/mcp --bearer-token-env-var UIZZE_AGENT_TOKEN
+The optional **paid MCP** connects your agent to focused reference and material search:
+
+| Tool | What your agent gets |
+| --- | --- |
+| `find_ui_references` | Up to three full-screen references per result, drawn from UIZZE's web and iOS library |
+| `find_ui_materials` | Up to three hosted fonts, icons, animated icons, or explicitly requested packs |
+
+```text
+Find references for a team permissions screen with inherited roles and
+restricted actions. Explain which decisions would help our workflow,
+then implement them using our existing components and visual language.
 ```
 
-The MCP intentionally exposes two tools:
+Create an agent token in [UIZZE](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_mcp), then follow the [MCP setup guide](integrations/mcp). References inform the design; the agent builds the interface in your own product's style. If a search returns no useful evidence, continue from the project.
 
-- `find_ui_references` — find or inspect up to three full-screen references.
-- `find_ui_materials` — find up to three hosted fonts, icons, animated icons,
-  or explicitly requested packs.
+## Use it where you already build
 
-No result is a valid result. Agents should continue with the product's existing
-system instead of retrying or inventing advice.
+| Environment | Start here |
+| --- | --- |
+| Codex, Claude Code, Cursor | [Install and try your first task](examples/agent-workflows.md) |
+| GitHub Copilot | [UIZZE plugin in Awesome Copilot](https://github.com/github/awesome-copilot/tree/main/plugins/uizze) |
+| MCP clients | [GitHub MCP Registry](https://github.com/mcp/uizze/uizze) · [Connection guide](integrations/mcp) |
+| GitHub pull requests | [UI Slop Gate Action](integrations/github-action) · [Inspect actual example output](examples/pull-request-check.md) |
 
-## GitHub Action
+## Catch unfinished UI in pull requests
+
+The free **UI Slop Gate** checks changed frontend source for inert controls, missing state markers, hardcoded colors, and combinations of generic dashboard cues. Findings appear next to the code and in the workflow summary.
 
 ```yaml
 permissions:
   contents: read
 
 steps:
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v7
+    with:
+      fetch-depth: 2
+      persist-credentials: false
   - uses: uizze/uizze@v1
+    with:
+      fail-on: error
 ```
 
-The action performs a conservative source check on the GitHub runner. It does
-not upload source or replace visual, accessibility, security, or usability
-review. See [integrations/github-action](integrations/github-action).
+No account, API key, or source upload. This is a conservative source check; use rendered inspection and your normal accessibility and usability checks alongside it. [Copy a complete workflow →](integrations/github-action#usage)
 
-## Repository map
+## Explore the repository
 
-| Path | Purpose |
-| --- | --- |
-| [`skills/anti-ui-slop`](skills/anti-ui-slop) | Prevent or review generic UI |
-| [`skills/ui-design`](skills/ui-design) | Design, build, redesign, or improve interfaces |
-| [`skills/ui-radar`](skills/ui-radar) | Find and compare focused UI references |
-| [`integrations/mcp`](integrations/mcp) | Authenticated MCP setup and registry metadata |
-| [`integrations/github-action`](integrations/github-action) | Local pull-request source check |
-| [`integrations`](integrations) | Optional examples and host-specific packaging |
+- [Practical agent workflows](examples/agent-workflows.md): billing settings, data tables, permission screens, and native iOS.
+- [Reproduce a pull-request check](examples/pull-request-check.md): source, findings, and a local command.
+- [Next.js starter](integrations/nextjs-starter): an existing starting point for a product-specific interface.
+- [Storybook integration](integrations/storybook): review UI states alongside your components.
+- [Public distribution](DISTRIBUTION.md): maintained install and catalog paths.
 
-Production metadata is authoritative:
-
-- [Agent Skills index](https://uizze.com/.well-known/agent-skills/index.json)
-- [MCP manifest](https://uizze.com/.well-known/mcp.json)
-- [MCP server card](https://uizze.com/.well-known/mcp/server-card.json)
-- [Setup documentation](https://uizze.com/docs)
-
-Public directory status lives in [DISTRIBUTION.md](DISTRIBUTION.md). It is a
-short inventory, not a submission backlog.
+Production metadata: [skills index](https://uizze.com/.well-known/agent-skills/index.json) · [MCP manifest](https://uizze.com/.well-known/mcp.json) · [server card](https://uizze.com/.well-known/mcp/server-card.json) · [documentation](https://uizze.com/docs).
 
 ## License
 
-[MIT](LICENSE). Bundled third-party material retains its own notices and license.
+Uizze-authored repository code and text use [MIT](LICENSE) unless a more specific notice applies. Bundled skill playbooks retain their Apache-2.0 license and third-party notices. See [the license map](LICENSING.md) before redistributing a skill package.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: UIZZE UI Slop Gate
-description: Free GitHub Action that catches generic UI, missing states, inert controls, and token drift before they ship.
+description: Catch unfinished UI in pull requests with checks for inert controls, missing state markers, hardcoded colors, and generic dashboard cues.
 author: UIZZE
 
 branding:
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: error
   show-uizze-link:
-    description: Offer an optional recorded comparison after useful scan results in the job summary.
+    description: Link to free UI workflows and optional reference search after scan results. Set false to omit links.
     required: false
     default: "true"
   max-files:

--- a/examples/agent-workflows.md
+++ b/examples/agent-workflows.md
@@ -1,48 +1,83 @@
-# STOP UI SLOP in every coding agent
+# Build better UI with your coding agent
 
-The same free finish-gate workflow works in Codex, Claude Code, Cursor, and GitHub Copilot. It needs no account or token.
+Use these prompts on a real file or route in your project. Replace the example page with yours and give the agent the product context it needs.
 
 ## Install once
 
 ```bash
-npx skills add https://uizze.com --skill anti-ui-slop
+npx skills add https://uizze.com --skill ui-design
 ```
 
-## Codex
+For a focused review of generic UI, install `anti-ui-slop` instead. Both work without an account or MCP connection. GitHub installs also work: `npx skills add uizze/uizze --skill ui-design`.
+
+## Billing settings that people can use
 
 ```text
-Use anti-ui-slop. Inspect this product before choosing a layout, write the design contract, implement every required state, and do not stop until the finish gate passes.
+Use ui-design on our billing settings route. Make the current plan, renewal
+date, payment method, and invoice history easy to scan. Separate routine
+edits from canceling the subscription. Use our existing components and
+tokens. Handle loading, no invoices, payment failure, and read-only access.
+Inspect desktop and mobile output and fix visible breakage.
 ```
 
-## Claude Code
+Check that a user can identify their plan and find the right action without reading the whole page. Keep destructive actions distinct and explain any disabled controls.
 
-Install the repository as a Claude Code plugin:
+## A data table beyond the happy path
 
 ```text
-/plugin marketplace add uizze/uizze
-/plugin install uizze@uizze
+Use ui-design to improve our orders table. Preserve the data and behavior.
+Prioritize order status, customer, amount, and the action users take next.
+Keep filters and pagination usable on small screens. Implement loading,
+no orders, no filter matches, and failed loading with retry. Reuse the
+project's table, input, button, and status components.
 ```
 
-Then run:
+Treat “no records yet” and “no matches for this filter” as different states. Confirm that users can recover from both.
+
+## Permissions without guesswork
 
 ```text
-Use uizze:anti-ui-slop to identify generic UI decisions and finish this interface in the product's existing visual language.
+Use ui-design on our team permissions screen. Make assigned and inherited
+roles distinguishable. Explain why an action is restricted and what the
+user can do next. Preserve our permission logic. Cover pending invites,
+expired invites, read-only users, save failures, and narrow layouts.
 ```
 
-## Cursor
+If the authenticated UIZZE MCP is connected, add a specific reference request: “Find up to three relevant full-screen references for role inheritance and restricted actions. Explain the decisions worth adapting to our product.”
 
-Use the installed `anti-ui-slop` skill before the first UI edit and again as the final review:
+## A focused review of a generic first draft
 
 ```text
-Run anti-ui-slop on the current UI. Fix every blocking product-specificity, state, interaction, responsive, accessibility, and design-system issue before declaring it finished.
+Use anti-ui-slop on this screen. Read the product brief and existing design
+system. Identify the three changes that would make this interface more
+specific to our users. Implement them, finish required states, and inspect
+the rendered result. Keep behavior and brand conventions intact.
 ```
 
-## GitHub Copilot
+## Native iOS refinement
 
-The skill is also live in [github/awesome-copilot](https://github.com/github/awesome-copilot/tree/main/skills/anti-ui-slop). Ask Copilot to use `anti-ui-slop` when planning or reviewing frontend changes.
+```text
+Use ui-design to refine this iOS settings screen. Follow the app's existing
+navigation, typography, controls, and spacing. Make account and notification
+preferences easy to find. Check long labels, Dynamic Type, disabled states,
+and the device sizes supported by the project.
+```
 
-## Pull-request gate
+## Choose your agent
 
-Copy [the least-privilege workflow](../.github/workflows/uizze-ui-review.yml) into a repository. It scans changed frontend files locally on the GitHub runner, emits file/line annotations and a concise job summary, and never transmits source or screenshots.
+| Agent | How to start |
+| --- | --- |
+| Codex | Install the skill, open the target project, and use one of the prompts above. |
+| Claude Code | Install the skill, or add the plugin with `/plugin marketplace add uizze/uizze` followed by `/plugin install uizze@uizze`. Ask for `uizze:anti-ui-slop` when using the plugin. |
+| Cursor | Install the skill and ask the agent to use `ui-design` or `anti-ui-slop` on a named file or route. |
+| GitHub Copilot | Follow the [UIZZE plugin instructions in Awesome Copilot](https://github.com/github/awesome-copilot/tree/main/plugins/uizze), then ask for `anti-ui-slop`. |
 
-For focused reference or hosted-material search, connect the authenticated UIZZE MCP from https://uizze.com/docs.
+## Add focused reference search
+
+Connect the optional [paid MCP](../integrations/mcp) when a real visual question would benefit from examples in UIZZE's 800,000+ web and iOS screens. The server provides `find_ui_references` and `find_ui_materials`.
+
+Name the problem: “invoice table on a narrow viewport” gives the agent a clearer research task than “find inspiration.” Adapt useful decisions to your product's components and content. If retrieval returns nothing, continue from the project.
+
+[Explore UIZZE →](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=workflow_examples)
+
+For a local source check on pull requests, [inspect the Action example](pull-request-check.md).

--- a/examples/pull-request-check.md
+++ b/examples/pull-request-check.md
@@ -1,0 +1,57 @@
+# Inspect a real UI Slop Gate result
+
+This example runs the Action's source checker against its checked-in test fixture. You can reproduce it locally with Node.js 20 or newer. It demonstrates the source checks, not the visual quality of a finished interface.
+
+## Input
+
+```tsx
+export function GenericDashboard() {
+  const metrics = useQuery(['metrics']);
+
+  return (
+    <main className="dashboard grid grid-cols-3 bg-white">
+      <a href="#">Overview</a>
+      {metrics.data.map((metric) => (
+        <article className="metric-card">Total Revenue: {metric.value}</article>
+      ))}
+    </main>
+  );
+}
+```
+
+## Actual output
+
+## UIZZE UI Slop Gate
+
+Scanned **1** changed frontend file: **1** error, **3** warnings.
+
+| Severity | Rule | Location | Finding |
+| --- | --- | --- | --- |
+| error | inert-control | integrations/github-action/test/fixtures/problematic.tsx:6 | Placeholder href="#" leaves this control without a destination. |
+| warning | design-token-drift | integrations/github-action/test/fixtures/problematic.tsx:5 | Hardcoded color "bg-white" may bypass the product design system; prefer an existing semantic token. |
+| warning | missing-ui-states | integrations/github-action/test/fixtures/problematic.tsx:2 | Data-driven UI has no visible loading, empty, error state marker. Add the state or record reviewed evidence in the manifest. |
+| warning | generic-dashboard-cues | integrations/github-action/test/fixtures/problematic.tsx:1 | This screen combines several generic dashboard cues. Verify its hierarchy and metrics are specific to the product task. |
+
+The placeholder link is an error. The state, color, and dashboard findings are warnings for a reviewer to assess in the project's context. State markers can live outside this file; use the reviewed-state manifest when appropriate.
+
+## Reproduce it
+
+Run from the repository root:
+
+```bash
+INPUT_FILES=integrations/github-action/test/fixtures/problematic.tsx \
+INPUT_FAIL_ON=never \
+INPUT_SHOW_UIZZE_LINK=false \
+node integrations/github-action/dist/index.js
+```
+
+The command prints GitHub workflow annotations. `fail-on: never` lets you inspect the findings without failing the process. In GitHub Actions, the runner also receives a Markdown job summary.
+
+## Work through the findings
+
+- Give the link a real destination or replace it with the correct control.
+- Implement loading, empty, and error behavior, or record states already reviewed elsewhere in the product.
+- Use an existing semantic color token when the hardcoded value bypasses the design system.
+- Check that the metrics and hierarchy serve the actual product task. A dashboard is not a defect by itself.
+
+[Copy the complete Action workflow](../integrations/github-action#usage) or [try a free UI workflow in your agent](agent-workflows.md).

--- a/integrations/benchmark/site/recordings/billing-settings-v1/README.md
+++ b/integrations/benchmark/site/recordings/billing-settings-v1/README.md
@@ -34,6 +34,8 @@ credentials, paid content, or generated comparison imagery is included here.
 
 ## What to do with this
 
-Use the [free UIZZE finish gate](https://benchmark.uizze.com/#quick-start) on
-your own screen first. If the screen needs real visual references and a
-contract/audit workflow inside the agent, [connect UIZZE](https://uizze.com).
+This July 2026 recording documents a historical workflow. Use the
+[current free agent workflows](../../../../../examples/agent-workflows.md)
+for a new task. The optional authenticated MCP now provides focused
+reference and hosted-material search through `find_ui_references` and
+`find_ui_materials`; see the [current connection guide](../../../../mcp).

--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -37,9 +37,10 @@ jobs:
   ui-slop-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
+          persist-credentials: false
       - uses: uizze/uizze@v1
         with:
           fail-on: error
@@ -54,14 +55,16 @@ The action needs no token, account, API key, write permission, or network access
 | `files` | changed frontend files | Optional comma- or newline-separated local paths. |
 | `manifest` | none | Optional path to local evidence JSON. |
 | `fail-on` | `error` | Fail on `error`, `warning`, or `never`. |
-| `show-uizze-link` | `true` | Offer optional free visual and agent follow-ups after useful results. |
+| `show-uizze-link` | `true` | Link to free agent workflows and optional reference search after scan results. Set `false` to omit links. |
 | `max-files` | `200` | Scan cap, limited internally to 1–1000. |
 
 Each file is capped at 1 MiB. Generated, dependency, build, and vendor folders are ignored. Explicit paths are also constrained to the checked-out workspace.
 
-## Optional recorded comparison
+## See what the Action finds
 
-Want to see the boundary of this workflow before trying it? [Inspect one recorded same-prompt case](https://benchmark.uizze.com/recordings/billing-settings-v1/): the seed, raw captures, diffs, and a narrow 96/100 to 98/100 result are public. It is one recorded case, not a benchmark result or quality guarantee.
+[Inspect a reproducible source check](../../examples/pull-request-check.md): the input, four findings, and a command you can run locally. For the next UI task, try the [free agent workflows](../../examples/agent-workflows.md) for billing settings, permission screens, or data tables.
+
+Start with `fail-on: never` if you want to review findings before making the check required. The default `fail-on: error` blocks explicit inert controls while keeping heuristic findings as warnings.
 
 ## Optional review evidence
 

--- a/integrations/github-action/action.yml
+++ b/integrations/github-action/action.yml
@@ -1,5 +1,5 @@
 name: UIZZE UI Slop Gate
-description: Free GitHub Action that checks every pull request for generic UI, missing states, inert controls, and token drift.
+description: Catch unfinished UI in pull requests with checks for inert controls, missing state markers, hardcoded colors, and generic dashboard cues.
 author: UIZZE
 
 branding:
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: error
   show-uizze-link:
-    description: Offer optional free visual and agent follow-ups after useful scan results in the job summary.
+    description: Link to free UI workflows and optional reference search after scan results. Set false to omit links.
     required: false
     default: "true"
   max-files:

--- a/integrations/github-action/dist/lib/report.js
+++ b/integrations/github-action/dist/lib/report.js
@@ -27,7 +27,7 @@ function buildSummary({ files, findings, skipped, showUizzeLink }) {
     lines.push('', 'No changed frontend files were available to inspect.');
   }
   if (showUizzeLink && files.length) {
-    lines.push('', 'Want to inspect a real same-prompt case first? [Open the recorded comparison](https://benchmark.uizze.com/recordings/billing-settings-v1/): raw captures, diffs, and a narrow 96/100 to 98/100 result—not a benchmark or quality guarantee.');
+    lines.push('', 'Use the [free UIZZE UI workflows](https://github.com/uizze/uizze/blob/main/examples/agent-workflows.md) to work through these findings with your coding agent. For focused reference search, [explore UIZZE](https://uizze.com/?utm_source=github&utm_medium=action&utm_campaign=discovery&utm_content=job_summary).');
   }
   return `${lines.join('\n')}\n`;
 }

--- a/integrations/github-action/package.json
+++ b/integrations/github-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze-ui-slop-gate-action",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "Catch UI slop in every pull request before it ships.",
   "license": "MIT",

--- a/integrations/github-action/src/lib/report.js
+++ b/integrations/github-action/src/lib/report.js
@@ -27,7 +27,7 @@ function buildSummary({ files, findings, skipped, showUizzeLink }) {
     lines.push('', 'No changed frontend files were available to inspect.');
   }
   if (showUizzeLink && files.length) {
-    lines.push('', 'Want to inspect a real same-prompt case first? [Open the recorded comparison](https://benchmark.uizze.com/recordings/billing-settings-v1/): raw captures, diffs, and a narrow 96/100 to 98/100 result—not a benchmark or quality guarantee.');
+    lines.push('', 'Use the [free UIZZE UI workflows](https://github.com/uizze/uizze/blob/main/examples/agent-workflows.md) to work through these findings with your coding agent. For focused reference search, [explore UIZZE](https://uizze.com/?utm_source=github&utm_medium=action&utm_campaign=discovery&utm_content=job_summary).');
   }
   return `${lines.join('\n')}\n`;
 }

--- a/integrations/github-action/test/report.test.js
+++ b/integrations/github-action/test/report.test.js
@@ -22,17 +22,20 @@ test('annotation level can follow the configured failure threshold', () => {
   assert.match(writes[0], /^::warning /);
 });
 
-test('summary puts the optional recorded comparison after useful scan results', () => {
+test('summary puts optional current workflows after useful scan results and respects opt-out', () => {
   const summary = buildSummary({ files: ['src/A.tsx'], findings: [warning], skipped: [], showUizzeLink: true });
-  assert.ok(summary.indexOf('test-rule') < summary.indexOf('recorded comparison'));
-  assert.match(summary, /https:\/\/benchmark\.uizze\.com\/recordings\/billing-settings-v1\//);
-  assert.match(summary, /not a benchmark or quality guarantee/);
+  assert.ok(summary.indexOf('test-rule') < summary.indexOf('free UIZZE UI workflows'));
+  assert.match(summary, /https:\/\/github\.com\/uizze\/uizze\/blob\/main\/examples\/agent-workflows\.md/);
+  assert.match(summary, /utm_medium=action/);
+  assert.doesNotMatch(summary, /benchmark\.uizze\.com|96\/100|98\/100/);
   assert.equal(summary.includes(['/mcp', 'preview'].join('/')), false);
   assert.equal(summary.includes(['check', 'ui', 'slop'].join('_')), false);
-  assert.doesNotMatch(summary, /uizze\.com\?/);
+  const disabled = buildSummary({ files: ['src/A.tsx'], findings: [warning], skipped: [], showUizzeLink: false });
+  assert.match(disabled, /test-rule/);
+  assert.doesNotMatch(disabled, /https:\/\//);
   const empty = buildSummary({ files: [], findings: [], skipped: [], showUizzeLink: true });
   assert.doesNotMatch(empty, /uizze\.com/);
-  assert.doesNotMatch(empty, /recorded comparison/);
+  assert.doesNotMatch(empty, /free UIZZE UI workflows/);
 });
 
 test('failure threshold respects error, warning, and never', () => {

--- a/plugins/claude-directory/README.md
+++ b/plugins/claude-directory/README.md
@@ -1,0 +1,29 @@
+# UIZZE for Claude Code
+
+Build interfaces that look like your product with the free `anti-ui-slop` skill. Use the product brief, existing components, and design system to improve hierarchy, content, interaction states, and the rendered result.
+
+## Try it
+
+Install through your host catalog, or install the canonical skill:
+
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
+
+```text
+Use anti-ui-slop on our settings page. Make the main actions easy to find,
+reuse our components and tokens, finish loading, empty, error, and permission
+states, and inspect the rendered result before finishing.
+```
+
+The free package includes the skill, focused playbooks, and reference policy. It needs no account, runtime script, or MCP connection.
+
+## Add focused reference search
+
+The optional paid UIZZE MCP gives your agent access to references from 800,000+ real web and iOS screens through `find_ui_references`, plus hosted design materials through `find_ui_materials`. Connect it separately when a specific visual question needs evidence.
+
+[MCP setup](https://github.com/uizze/uizze/tree/main/integrations/mcp) · [Practical workflows](https://github.com/uizze/uizze/blob/main/examples/agent-workflows.md) · [Explore UIZZE](https://uizze.com)
+
+## License
+
+The package combines Uizze's MIT entry point with Apache-2.0 design-stack playbooks. Keep the bundled LICENSE, NOTICE, and modification notices with redistributed files. See the [license map](https://github.com/uizze/uizze/blob/main/LICENSING.md).


### PR DESCRIPTION
Visitors can now start a real UI task from the repository, compare the three free skills, and find the optional MCP connection path. The README surfaces the 800,000+ screen library, current Copilot and MCP registry entries, and practical prompts for billing settings, tables, permissions, and iOS.

The Action's optional follow-up replaces the broken hosted benchmark link with current workflows and reference search. A checked-in example reproduces four findings from the existing fixture. The license map explains the MIT entry point and Apache-2.0 bundled playbooks while preserving every package license and checksum. Owned links identify their GitHub surface for attribution.

Validation: 17 Action tests plus packaged-runtime verification, 4 benchmark tests, 3 finish-gate tests, successful clean ui-design installs from both the domain and GitHub, canonical package checksum checks, relative link checks, and git diff --check.
