### PR TITLE
Keep the Action description valid for Marketplace publication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: UIZZE UI Slop Gate
-description: Catch unfinished UI in pull requests with checks for inert controls, missing state markers, hardcoded colors, and generic dashboard cues.
+description: Catch unfinished UI in pull requests with checks for inert controls, missing states, color drift, and generic layouts.
 author: UIZZE
 
 branding:

--- a/integrations/github-action/action.yml
+++ b/integrations/github-action/action.yml
@@ -1,5 +1,5 @@
 name: UIZZE UI Slop Gate
-description: Catch unfinished UI in pull requests with checks for inert controls, missing state markers, hardcoded colors, and generic dashboard cues.
+description: Catch unfinished UI in pull requests with checks for inert controls, missing states, color drift, and generic layouts.
 author: UIZZE
 
 branding:

--- a/integrations/github-action/scripts/check-dist.js
+++ b/integrations/github-action/scripts/check-dist.js
@@ -6,6 +6,8 @@ const path = require('node:path');
 
 const root = path.resolve(__dirname, '..');
 const metadata = fs.readFileSync(path.join(root, 'action.yml'), 'utf8');
+const description = metadata.match(/^description:\s*(.+)$/m)?.[1];
+assert.ok(description && description.length < 125, 'Marketplace description must be under 125 characters');
 assert.match(metadata, /using:\s*node24/);
 assert.match(metadata, /main:\s*dist\/index\.js/);
 assert.ok(fs.existsSync(path.join(root, 'dist', 'index.js')), 'dist/index.js is missing');


### PR DESCRIPTION
Shortens the Action description to 118 characters to satisfy the Marketplace release form and adds the limit to packaged-runtime verification. Both root and integration metadata match. All 17 Action tests and npm run verify pass.