### PR TITLE
Show the UI Slop Gate in live GitHub example jobs

### DIFF
--- a/.github/workflows/ui-slop-gate-example.yml
+++ b/.github/workflows/ui-slop-gate-example.yml
@@ -1,0 +1,54 @@
+name: UI Slop Gate example
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/ui-slop-gate-example.yml
+      - integrations/github-action/test/fixtures/**
+  pull_request:
+    paths:
+      - .github/workflows/ui-slop-gate-example.yml
+      - integrations/github-action/test/fixtures/**
+
+permissions:
+  contents: read
+
+jobs:
+  example:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        include:
+          - label: Before - four findings
+            fixture: problematic.tsx
+            findings: '4'
+            fail-on: never
+          - label: After - no configured findings
+            fixture: finished.tsx
+            findings: '0'
+            fail-on: warning
+    steps:
+      - name: Check out the example source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run the published UIZZE Action
+        id: gate
+        uses: uizze/uizze@638ab4583b5db6593b0c5cc5304d6b03932ec46d # v1.2.15
+        with:
+          files: integrations/github-action/test/fixtures/${{ matrix.fixture }}
+          fail-on: ${{ matrix.fail-on }}
+
+      - name: Verify the documented example result
+        env:
+          EXPECTED_FINDINGS: ${{ matrix.findings }}
+          ACTUAL_FINDINGS: ${{ steps.gate.outputs.finding-count }}
+          SCANNED_FILES: ${{ steps.gate.outputs.scanned-files }}
+        run: |
+          test "$SCANNED_FILES" = '1'
+          test "$ACTUAL_FINDINGS" = "$EXPECTED_FINDINGS"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ steps:
       fail-on: error
 ```
 
-No account, API key, or source upload. This is a conservative source check; use rendered inspection and your normal accessibility and usability checks alongside it. [Copy a complete workflow →](integrations/github-action#usage)
+No account, API key, or source upload. [Watch the published Action check a before-and-after example](https://github.com/uizze/uizze/actions/workflows/ui-slop-gate-example.yml), then [copy the complete workflow](integrations/github-action#usage). This is a conservative source check; use rendered inspection and your normal accessibility and usability checks alongside it.
 
 ## Explore the repository
 

--- a/examples/pull-request-check.md
+++ b/examples/pull-request-check.md
@@ -2,6 +2,10 @@
 
 This example runs the Action's source checker against its checked-in test fixture. You can reproduce it locally with Node.js 20 or newer. It demonstrates the source checks, not the visual quality of a finished interface.
 
+[**Inspect the live GitHub run →**](https://github.com/uizze/uizze/actions/workflows/ui-slop-gate-example.yml)
+The workflow runs both snippets with the published v1.2.15 Action and verifies
+their expected finding counts. Open a run to see the annotations and job summaries.
+
 ## Input
 
 ```tsx
@@ -34,6 +38,26 @@ Scanned **1** changed frontend file: **1** error, **3** warnings.
 
 The placeholder link is an error. The state, color, and dashboard findings are warnings for a reviewer to assess in the project's context. State markers can live outside this file; use the reviewed-state manifest when appropriate.
 
+## Compare the revised source
+
+The [revised fixture](../integrations/github-action/test/fixtures/finished.tsx)
+uses a workspace-usage task, a destination path, an explicit empty-data branch,
+loading and error messages, and a semantic surface class. Running the same
+checker on it produces **0 findings**.
+
+| Before | Revised source |
+| --- | --- |
+| `href="#"` | `/settings/usage` destination |
+| Query data rendered immediately | Loading, error, and `length === 0` branches |
+| `bg-white` | `bg-surface` semantic class |
+| Generic dashboard metrics in cards | A workspace-usage list with labels from its data |
+
+Both files are illustrative source fixtures. The query hook, destination route,
+and semantic class must be supplied by the host product; these snippets are not
+a standalone application. Zero findings means these configured source rules
+found nothing. It does not verify the destination exists, the styles render
+correctly, or the screen is accessible.
+
 ## Reproduce it
 
 Run from the repository root:
@@ -46,6 +70,19 @@ node integrations/github-action/dist/index.js
 ```
 
 The command prints GitHub workflow annotations. `fail-on: never` lets you inspect the findings without failing the process. In GitHub Actions, the runner also receives a Markdown job summary.
+
+Then run the revised snippet with warnings treated as failures:
+
+```bash
+INPUT_FILES=integrations/github-action/test/fixtures/finished.tsx \
+INPUT_FAIL_ON=warning \
+INPUT_SHOW_UIZZE_LINK=false \
+node integrations/github-action/dist/index.js
+```
+
+The process exits successfully with zero findings. The
+[example workflow](../.github/workflows/ui-slop-gate-example.yml) checks both
+the number of scanned files and the finding count for each snippet.
 
 ## Work through the findings
 

--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -1,28 +1,32 @@
-> **Stop AI coding agents from shipping generic UI.**
+# UIZZE UI Slop Gate
 
-# Stop Making UI Slop
-
-Build product-specific UI with a conservative local source check. Optional
-UIZZE reference search is available separately at [uizze.com](https://uizze.com/github-action).
+**Catch unfinished UI in pull requests.** Find placeholder controls, missing
+state markers, color drift, and generic dashboard cues before the next review.
+Free, dependency-free, and local to your GitHub runner.
 
 ![Stop Making UI Slop with UIZZE](https://uizze.com/landing/anti-ui-slop-skill-banner.png)
 
-## Catch UI Slop in Every Pull Request
+[**Inspect the live example →**](https://github.com/uizze/uizze/actions/workflows/ui-slop-gate-example.yml) · [Add it to your repository](#usage) · [Work through the findings](../../examples/agent-workflows.md)
+
+## What it catches
 
 Your tests can pass while the UI still looks generated. This free GitHub Action catches concrete finish risks in changed frontend code before they ship. It runs entirely inside the job: no source, screenshots, or scan results leave the runner.
 
 It checks changed JS, TS, JSX, TSX, CSS, HTML, Vue, and Svelte files for conservative signals:
 
-- explicitly inert or placeholder controls;
-- data-driven UI with no visible loading, empty, or error-state markers;
-- hardcoded color values that may bypass semantic design tokens; and
-- combinations of generic dashboard, card-grid, and placeholder-metric cues.
+| Source signal | Example | Default severity |
+| --- | --- | --- |
+| Explicitly unfinished control | `href="#"` or an empty click handler | Error |
+| Missing state markers | A query-backed screen without loading, empty, or error markers | Warning |
+| Color drift | Hardcoded colors that may bypass the product's semantic tokens | Warning |
+| Generic dashboard cues | Several dashboard, card-grid, and placeholder-metric cues together | Warning |
 
 Findings appear as workflow annotations and in the job summary. It is a focused source check, not a visual, accessibility, correctness, or security audit.
 
 ## Usage
 
-Pin a released version rather than a branch:
+Create `.github/workflows/ui-finish-gate.yml` in your repository. Start with
+`fail-on: never` to inspect findings while your existing checks keep working:
 
 ```yaml
 name: UI finish gate
@@ -37,16 +41,24 @@ jobs:
   ui-slop-gate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
           persist-credentials: false
-      - uses: uizze/uizze@v1
+      - uses: uizze/uizze@638ab4583b5db6593b0c5cc5304d6b03932ec46d # v1.2.15
         with:
-          fail-on: error
+          fail-on: never
 ```
 
-The action needs no token, account, API key, write permission, or network access. For stronger supply-chain pinning, replace `@v1` with the release commit SHA.
+The workflow pins [v1.2.15](https://github.com/uizze/uizze/releases/tag/v1.2.15)
+to its immutable commit. Use `uizze/uizze@v1` if you prefer updates within the
+maintained major version. The Action itself needs no token, account, API key,
+write permission, or network access.
+
+After the first run, open its **Summary** to review findings and source
+locations. Change `fail-on` to `error` to block explicitly unfinished controls,
+or `warning` to block all configured findings. `never` reports every finding
+as a warning annotation and keeps the Action step successful.
 
 ## Inputs
 
@@ -62,9 +74,19 @@ Each file is capped at 1 MiB. Generated, dependency, build, and vendor folders a
 
 ## See what the Action finds
 
-[Inspect a reproducible source check](../../examples/pull-request-check.md): the input, four findings, and a command you can run locally. For the next UI task, try the [free agent workflows](../../examples/agent-workflows.md) for billing settings, permission screens, or data tables.
+[Open the live example workflow](https://github.com/uizze/uizze/actions/workflows/ui-slop-gate-example.yml)
+to compare two jobs: the original snippet produces four findings; the revised
+snippet produces none. Both run the published Action with the same read-only
+permissions as the installation above. The example checks its expected output
+so the demonstration cannot silently drift.
 
-Start with `fail-on: never` if you want to review findings before making the check required. The default `fail-on: error` blocks explicit inert controls while keeping heuristic findings as warnings.
+[Inspect the source and reproduce both results](../../examples/pull-request-check.md).
+These are source-check examples, not a rendered application or a visual-quality
+score. For your next UI task, try the [free agent workflows](../../examples/agent-workflows.md)
+for billing settings, permission screens, or data tables.
+
+Need product-specific reference screens while fixing a finding? Optional UIZZE
+reference search is available separately at [uizze.com](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=action_readme).
 
 ## Optional review evidence
 

--- a/integrations/github-action/test/fixtures/finished.tsx
+++ b/integrations/github-action/test/fixtures/finished.tsx
@@ -1,0 +1,19 @@
+export function WorkspaceUsage() {
+  const metrics = useQuery(['metrics']);
+
+  if (metrics.isLoading) return <p role="status">Loading workspace usage…</p>;
+  if (metrics.error) return <p role="alert">Workspace usage could not be loaded.</p>;
+  if (!metrics.data || metrics.data.length === 0) return <p>No usage recorded for this workspace yet.</p>;
+
+  return (
+    <main className="bg-surface">
+      <h1>Workspace usage</h1>
+      <a href="/settings/usage">Manage usage limits</a>
+      <ul>
+        {metrics.data.map((metric) => (
+          <li key={metric.id}>{metric.label}: {metric.value}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
The Action's documentation shows source findings but gives prospective users no GitHub run to inspect. Add a small before/after workflow that runs the released v1.2.15 Action on two explicit fixtures, publishes real annotations and summaries, and checks the expected four/zero findings. It runs on relevant changes or manual dispatch, with read-only permissions and pinned actions.

The Action guide now opens with its purpose and rule severities, offers a complete immutable-version installation in report-only mode, and explains when to enable blocking. The main README and example guide link to the live workflow. The fixtures demonstrate source checks only; the docs explicitly distinguish them from a runnable application or visual-quality proof.

Validation: both documented local commands produce the expected result; the Action's 17 tests and packaged-runtime verification pass; `git diff --check` passes. The PR's example jobs must pass before merge. No runtime, rule, skill package, or release-tag change is included.
