### PR TITLE
Keep GitHub annotation punctuation readable

### DIFF
--- a/integrations/github-action/dist/lib/github.js
+++ b/integrations/github-action/dist/lib/github.js
@@ -2,11 +2,15 @@
 
 const fs = require('node:fs');
 
-function commandValue(value) {
+function commandData(value) {
   return String(value)
     .replaceAll('%', '%25')
     .replaceAll('\r', '%0D')
-    .replaceAll('\n', '%0A')
+    .replaceAll('\n', '%0A');
+}
+
+function commandValue(value) {
+  return commandData(value)
     .replaceAll(':', '%3A')
     .replaceAll(',', '%2C');
 }
@@ -19,7 +23,7 @@ function annotation(finding, write = console.log, forcedLevel = null) {
     `col=${finding.column}`,
     `title=${commandValue(`UIZZE ${finding.ruleId}`)}`,
   ].join(',');
-  write(`::${level} ${props}::${commandValue(finding.message)}`);
+  write(`::${level} ${props}::${commandData(finding.message)}`);
 }
 
 function setOutput(name, value, outputPath = process.env.GITHUB_OUTPUT) {

--- a/integrations/github-action/package.json
+++ b/integrations/github-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uizze-ui-slop-gate-action",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "Catch UI slop in every pull request before it ships.",
   "license": "MIT",

--- a/integrations/github-action/src/lib/github.js
+++ b/integrations/github-action/src/lib/github.js
@@ -2,11 +2,15 @@
 
 const fs = require('node:fs');
 
-function commandValue(value) {
+function commandData(value) {
   return String(value)
     .replaceAll('%', '%25')
     .replaceAll('\r', '%0D')
-    .replaceAll('\n', '%0A')
+    .replaceAll('\n', '%0A');
+}
+
+function commandValue(value) {
+  return commandData(value)
     .replaceAll(':', '%3A')
     .replaceAll(',', '%2C');
 }
@@ -19,7 +23,7 @@ function annotation(finding, write = console.log, forcedLevel = null) {
     `col=${finding.column}`,
     `title=${commandValue(`UIZZE ${finding.ruleId}`)}`,
   ].join(',');
-  write(`::${level} ${props}::${commandValue(finding.message)}`);
+  write(`::${level} ${props}::${commandData(finding.message)}`);
 }
 
 function setOutput(name, value, outputPath = process.env.GITHUB_OUTPUT) {

--- a/integrations/github-action/test/report.test.js
+++ b/integrations/github-action/test/report.test.js
@@ -8,11 +8,14 @@ const { buildSummary, shouldFail } = require('../src/lib/report');
 const warning = { file: 'src/A.tsx', line: 4, column: 2, ruleId: 'test-rule', severity: 'warning', message: 'Check: this, please' };
 const error = { ...warning, severity: 'error' };
 
-test('annotation escapes GitHub workflow command data', () => {
+test('annotation keeps message punctuation readable and escapes command boundaries', () => {
   const writes = [];
-  annotation(warning, (line) => writes.push(line));
-  assert.match(writes[0], /^::warning /);
-  assert.match(writes[0], /Check%3A this%2C please/);
+  annotation({
+    ...warning,
+    file: 'src/A,B:C.tsx',
+    message: 'Check: this, please\n50% complete\r\nNext',
+  }, (line) => writes.push(line));
+  assert.equal(writes[0], '::warning file=src/A%2CB%3AC.tsx,line=4,col=2,title=UIZZE test-rule::Check: this, please%0A50%25 complete%0D%0ANext');
   assert.equal(commandValue('a%b\nc'), 'a%25b%0Ac');
 });
 


### PR DESCRIPTION
The live example exposed `loading%2C empty%2C error` in GitHub's annotation UI. The emitter was applying property escaping to the message body, so GitHub displayed literal percent codes for commas and colons.

Use separate message and property escaping, matching [GitHub's toolkit implementation](https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts). Messages preserve punctuation; percent signs and line breaks stay escaped, and file/title properties retain separator escaping. Update the regression test to verify both readable text and command-boundary safety, rebuild the packaged runtime, and bump the Action package to 1.0.11.

Validation: all 17 Action tests and packaged-runtime verification pass; `git diff --check` passes. Source scanning and failure thresholds are unchanged. The corrected output will also be checked in a real GitHub run when the patch is released.
