### PR TITLE
docs: run the public example on the corrected Action release

### DIFF
--- a/.github/workflows/ui-slop-gate-example.yml
+++ b/.github/workflows/ui-slop-gate-example.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run the published UIZZE Action
         id: gate
-        uses: uizze/uizze@638ab4583b5db6593b0c5cc5304d6b03932ec46d # v1.2.15
+        uses: uizze/uizze@672deb24a980bc1d152ef2a40d371dad15cb2f65 # v1.2.16
         with:
           files: integrations/github-action/test/fixtures/${{ matrix.fixture }}
           fail-on: ${{ matrix.fail-on }}

--- a/examples/pull-request-check.md
+++ b/examples/pull-request-check.md
@@ -3,7 +3,7 @@
 This example runs the Action's source checker against its checked-in test fixture. You can reproduce it locally with Node.js 20 or newer. It demonstrates the source checks, not the visual quality of a finished interface.
 
 [**Inspect the live GitHub run →**](https://github.com/uizze/uizze/actions/workflows/ui-slop-gate-example.yml)
-The workflow runs both snippets with the published v1.2.15 Action and verifies
+The workflow runs both snippets with the published v1.2.16 Action and verifies
 their expected finding counts. Open a run to see the annotations and job summaries.
 
 ## Input

--- a/integrations/github-action/README.md
+++ b/integrations/github-action/README.md
@@ -45,12 +45,12 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
-      - uses: uizze/uizze@638ab4583b5db6593b0c5cc5304d6b03932ec46d # v1.2.15
+      - uses: uizze/uizze@672deb24a980bc1d152ef2a40d371dad15cb2f65 # v1.2.16
         with:
           fail-on: never
 ```
 
-The workflow pins [v1.2.15](https://github.com/uizze/uizze/releases/tag/v1.2.15)
+The workflow pins [v1.2.16](https://github.com/uizze/uizze/releases/tag/v1.2.16)
 to its immutable commit. Use `uizze/uizze@v1` if you prefer updates within the
 maintained major version. The Action itself needs no token, account, API key,
 write permission, or network access.


### PR DESCRIPTION
The public example and copy-paste workflow still used v1.2.15, whose annotations displayed percent-encoded commas. Pin both to the tested v1.2.16 release and update the example's version label.

The live matrix checks one source file per job and asserts four findings before the repair and zero afterward. The release passes all 17 Action tests and packaged-runtime verification. This PR reruns the two jobs against the published release.
