### PR TITLE
Show the UIZZE before-and-after video before setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@
 
 [**Explore UIZZE →**](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_product) · [Try a workflow](examples/agent-workflows.md) · [Connect MCP](integrations/mcp) · [Add the PR check](integrations/github-action)
 
+## Watch UIZZE before and after
+
+30-second mobile UI comparison: **No skills** on the left, **MCP + Skills** on the right.
+
+https://github.com/user-attachments/assets/0137638f-d963-4e6b-a1a6-d7e2dce87600
+
+[**Build your next screen with UIZZE →**](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_video)
+
 ## Start with your next screen
 
 Install the free UI design skill:


### PR DESCRIPTION
Show the existing 30-second UIZZE comparison video before the install instructions, so visitors can inspect the mobile flows labeled No skills and MCP + Skills. Add a website follow-up link with attribution for this placement.

The original MP4 is hosted as a GitHub attachment and plays inline. The existing banner stays in place; no video binary is added to the repository. No skill contents or runtime code changed.

Video to embed:

https://github.com/user-attachments/assets/0137638f-d963-4e6b-a1a6-d7e2dce87600
