### PR TITLE
Help plugin users try a first screen and connect paid references

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ https://github.com/user-attachments/assets/0137638f-d963-4e6b-a1a6-d7e2dce87600
 
 [**Build your next screen with UIZZE →**](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=readme_video)
 
+[Try a billing screen in Claude Code, Cursor, or Copilot](examples/first-screen.md): install, copy the brief, connect optional reference search, and check the result.
+
 ## Start with your next screen
 
 Install the free UI design skill:

--- a/examples/first-screen.md
+++ b/examples/first-screen.md
@@ -1,0 +1,128 @@
+# Try UIZZE on one screen
+
+Take a billing settings page from your project and give your coding agent one
+specific task. You'll check the current plan, payment details, invoices, and
+the states users encounter when something goes wrong.
+
+[Watch the 30-second mobile comparison](https://github.com/uizze/uizze#watch-uizze-before-and-after)
+to see UIZZE in use. This billing exercise is a separate walkthrough you can
+run in your own project.
+
+## Choose a starting point
+
+Open your project in Claude Code, Cursor, or GitHub Copilot and identify the
+billing route or component. Keep the existing design system and billing logic.
+
+If you need a practice project, copy our small HTML/CSS/JavaScript seed:
+
+```bash
+git clone --depth 1 https://github.com/uizze/uizze.git uizze-examples
+cp -R uizze-examples/integrations/benchmark/site/recordings/billing-settings-v1/seed uizze-first-screen
+cd uizze-first-screen
+```
+
+The seed provides an unfinished billing page for a fictional product and has no dependencies to install.
+Its interface lives in `index.html`, `styles.css`, and `app.js`. Use Node.js
+to run its source check with `npm run verify`. The initial seed fails this check
+because you haven't implemented the page yet. The check looks for required
+terms and CSS variables; you'll inspect behavior in the browser too.
+
+## Install in your agent
+
+### Claude Code
+
+Run these commands inside Claude Code:
+
+```text
+/plugin marketplace add uizze/uizze
+/plugin install uizze@uizze
+```
+
+Follow the install summary if Claude asks you to reload. Start the task with
+`/uizze:anti-ui-slop`, then paste the brief below.
+
+### Cursor
+
+Run this command from your project terminal and select Cursor in the installer:
+
+```bash
+npx skills add https://uizze.com --skill anti-ui-slop
+```
+
+Open Agent in that project and ask it to use `anti-ui-slop` with the brief below.
+
+### GitHub Copilot CLI
+
+Install the [UIZZE plugin in Awesome Copilot](https://github.com/github/awesome-copilot/tree/main/plugins/uizze):
+
+```bash
+copilot plugin install uizze@awesome-copilot
+```
+
+Open Copilot in your project and ask it to use `anti-ui-slop` with the brief below.
+
+## Give the agent this brief
+
+Name your actual route or component before pasting this:
+
+```text
+Use anti-ui-slop to improve this billing settings page.
+
+Read the existing components and design tokens first. Make the current plan,
+renewal date, payment method, and invoice history easy to scan. Separate
+routine edits from canceling the subscription. Preserve billing behavior.
+
+Cover loading, no invoices, payment failure with retry, and a successful
+update. Make the primary action clear at both desktop and mobile widths.
+Use the product's own content and visual language.
+
+Inspect the rendered result, fix clipping and inert controls, and tell me
+which states you verified and anything you couldn't check.
+```
+
+For the practice seed, add: “Implement the unfinished billing page using fictional
+example data. Only change `index.html`, `styles.css`, and `app.js`. Implement
+`?state=default|loading|empty|failed|success` using the existing state parameter
+and run `npm run verify` without changing the verifier.”
+
+## Bring real product references into the task
+
+The free skill works on its own. Connect the optional **paid UIZZE MCP** when
+you want the agent to research a specific design question across **800,000+
+real web and iOS screens**.
+
+[Connect UIZZE in Claude Code or Cursor](../integrations/mcp#claude-code),
+then add this to your brief:
+
+```text
+Before implementing, use UIZZE to find up to three relevant web references
+for billing settings with invoice history. Explain the hierarchy, density,
+and responsive table decisions worth adapting. Implement those decisions
+with our components and brand. If no relevant references return, continue
+from the project.
+```
+
+## Check the result
+
+Run your project's normal development server. For the practice seed, run this
+in a separate terminal from `uizze-first-screen`:
+
+```bash
+python3 -m http.server 4173 --bind 127.0.0.1
+```
+
+Open `http://127.0.0.1:4173/index.html?state=default` and try each state value.
+Check desktop and narrow mobile widths:
+
+- Can you find the current plan, payment method, and next action at a glance?
+- Can you recover from a failed operation and distinguish it from no invoices?
+- Do the controls work, and can you reach them with a keyboard?
+- Do long invoice labels and amounts fit without hiding useful information?
+
+Keep a screenshot before and after, the prompt, and any remaining problems.
+If you share the result, identify the agent and model you used and whether
+you connected MCP.
+
+[**Build your next screen with UIZZE →**](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=first_screen)
+
+[More tasks: tables, permissions, and native iOS](agent-workflows.md)

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -23,6 +23,70 @@ The server exposes exactly two tools:
 Use the product and its existing design system first. Retrieve evidence only
 for a concrete unresolved question, and do not retry an empty result.
 
+## Claude Code
+
+From your project directory, add UIZZE as a remote HTTP server:
+
+```bash
+claude mcp add --transport http uizze https://uizze.com/mcp
+```
+
+Open Claude Code, run `/mcp`, select `uizze`, and complete the browser sign-in.
+If you already configured a server named `uizze`, open its existing entry instead
+of adding it again. This command uses Claude Code's default local scope for the
+current project.
+
+The free plugin installs separately:
+
+```text
+/plugin marketplace add uizze/uizze
+/plugin install uizze@uizze
+```
+
+Follow the install summary if Claude asks you to reload plugins. Use
+`/uizze:anti-ui-slop` for a focused UI task.
+
+## Cursor
+
+Add this entry to `mcpServers` in your project's `.cursor/mcp.json`, preserving
+any servers already configured there:
+
+```json
+{
+  "mcpServers": {
+    "uizze": {
+      "url": "https://uizze.com/mcp"
+    }
+  }
+}
+```
+
+Open Cursor's MCP settings, enable `uizze`, and complete its OAuth sign-in when
+prompted. For access across projects, Cursor also supports `~/.cursor/mcp.json`.
+
+Install the free skill in your project with the command below, selecting Cursor
+when the installer asks for an agent. The skill and MCP connection are separate.
+
+## Try the connection
+
+Confirm your client's UIZZE entry shows the two tools listed above. Then ask:
+
+```text
+Use UIZZE to find up to three web UI references for a billing settings page
+with invoice history. Explain which hierarchy and table decisions would
+help our page. Keep our components, content, and brand.
+```
+
+The MCP requires an account with paid access. If your client shows a sign-in
+request, complete it first. If it reports an access or subscription problem,
+check your [UIZZE account](https://uizze.com/?utm_source=github&utm_medium=repository&utm_campaign=discovery&utm_content=mcp_connection).
+A connected server can return no relevant references; continue from your
+project in that case.
+
+For a complete task, [try your first screen](../../examples/first-screen.md).
+Client configuration references: [Claude Code MCP](https://code.claude.com/docs/en/mcp)
+and [Cursor MCP](https://cursor.com/docs/mcp).
+
 ## Install the free skill
 
 ```bash


### PR DESCRIPTION
Visitors watching the UIZZE demo can now follow a billing-screen walkthrough in Claude Code, Cursor, or Copilot. It includes installation, an optional dependency-free practice seed, a concrete brief, paid MCP reference search, and browser checks for the result. The MCP guide now documents Claude and Cursor setup alongside the existing Codex instructions.

The existing video, product CTAs, skill content, manifests, pricing, and promotional copy remain intact. The walkthrough identifies the existing video as a separate mobile example and does not claim a measured improvement or a reproduction of that recording.

Validation: Claude Code 2.1.220 validated the root marketplace, root plugin, and self-contained Claude package. A fresh isolated profile installed uizze@uizze 1.2.14 with all three skills; bundled checksums passed. The documented Claude HTTP configuration command succeeded in that isolated profile. Repository JSON, skill checksums, relative links, whitespace checks, and all 24 existing tests passed. The practice seed's initial verifier failure was confirmed and is documented as expected until the page is implemented. Authenticated paid MCP retrieval and a complete generated-interface run were not performed.
