### PR TITLE
Align Copilot marketplace with the released plugin version

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "A compact workflow for building and reviewing product-specific interfaces without generic UI defaults.",
-    "version": "1.2.14"
+    "version": "1.2.16"
   },
   "plugins": [
     {
       "name": "uizze-ui-slop",
       "source": "./",
       "description": "A compact workflow for building and reviewing product-specific interfaces without generic UI defaults.",
-      "version": "1.2.14"
+      "version": "1.2.16"
     }
   ]
 }

--- a/plugins/verify.mjs
+++ b/plugins/verify.mjs
@@ -7,6 +7,13 @@ const root = fileURLToPath(new URL('../', import.meta.url));
 const read = p => readFileSync(resolve(root, p), 'utf8');
 const json = p => JSON.parse(read(p));
 const listing = json('plugins/listing.json');
+const copilotManifest = json('plugin.json');
+const copilotMarketplace = json('.github/plugin/marketplace.json');
+const copilotEntry = copilotMarketplace.plugins.find(plugin => plugin.name === copilotManifest.name);
+assert(copilotEntry, 'Copilot marketplace must include the installable plugin');
+assert.equal(copilotEntry.version, copilotManifest.version, 'Copilot marketplace must advertise the current plugin version');
+assert.equal(copilotMarketplace.metadata.version, copilotManifest.version, 'Copilot catalog version must match its package');
+assert.equal(json('.github/plugin/plugin.json').version, copilotManifest.version, 'Copilot manifests must agree on version');
 const hash = p => createHash('sha256').update(readFileSync(p)).digest('hex');
 function files(path) {
   return readdirSync(path, { withFileTypes: true }).flatMap(e => e.isDirectory() ? files(resolve(path, e.name)) : [resolve(path, e.name)]);


### PR DESCRIPTION
The Copilot marketplace advertises 1.2.14 while both installable manifests declare 1.2.16. Align the catalog version and add checks to prevent this mismatch from recurring. Public descriptions, branding and MCP behavior are unchanged.

Validation: node plugins/verify.mjs passes; restoring the previous marketplace manifest makes the new version check fail as expected. git diff --check passes.